### PR TITLE
Paths and speed

### DIFF
--- a/WinUtils.cpp
+++ b/WinUtils.cpp
@@ -82,15 +82,9 @@ void GetAllFilesInFolderRecursive(const std::string& path, std::set<std::string>
 	{
 		if (!p.is_directory())
 		{
-#if __linux__
-			auto lastSlash = p.path().native().find_last_of("/");
-			auto tempDir = p.path().native().substr(0, lastSlash);
-			lastSlash = tempDir.find_last_of("/");
-#else
 			auto lastSlash = p.path().native().find_last_of(L"\\");
 			auto tempDir = p.path().native().substr(0, lastSlash);
 			lastSlash = tempDir.find_last_of(L"\\");
-#endif
 			auto dirName = tempDir.substr(lastSlash + 1, tempDir.length());
 			auto returnName = "/" + convertUTF16ToUTF8(dirName) + "/" + p.path().filename().string();
 			filenames.insert(returnName);

--- a/newParser.h
+++ b/newParser.h
@@ -20,16 +20,16 @@ namespace commonItems
 		parser& operator=(const parser&) = default;
 		parser& operator=(parser&&) = default;
 
-		void registerKeyword(std::string keyword, parsingFunction);
-		void registerRegex(std::string keyword, parsingFunction);
-		void registerKeyword(std::regex keyword, parsingFunction);
+		void registerKeyword(const std::string& keyword, const parsingFunction& function);
+		void registerRegex(const std::string& keyword, const parsingFunction& function);
+		void registerKeyword(const std::regex& keyword, const parsingFunction& function);
 		void parseStream(std::istream& theStream);
 		void parseFile(const std::string& filename);
 
 		void clearRegisteredKeywords() noexcept;
 
 		std::optional<std::string> getNextToken(std::istream& theStream);
-		std::optional<std::string> getNextTokenWithoutMatching(std::istream& theStream);
+		static std::optional<std::string> getNextTokenWithoutMatching(std::istream& theStream);
 
 	private:
 		std::map<std::string, parsingFunction> registeredKeywordStrings;


### PR DESCRIPTION
- added UTF8 path support to parseFile. path change is transparent so nothing will change in userland.
- a few windows functions used by eu4tovi2 were rewritten so they can support utf8 paths
- all the keyword copying from the parser has been dropped, speed increase is phenomenal.