### PR TITLE
Drop tabs from strings

### DIFF
--- a/WinUtils.cpp
+++ b/WinUtils.cpp
@@ -414,6 +414,7 @@ std::string normalizeUTF8Path(const std::string& utf_8_path)
 	std::replace(asciiPath.begin(), asciiPath.end(), '<', '_');
 	std::replace(asciiPath.begin(), asciiPath.end(), '>', '_');
 	std::replace(asciiPath.begin(), asciiPath.end(), '|', '_');
+	asciiPath.erase(std::remove(asciiPath.begin(), asciiPath.end(), '\t'), asciiPath.end());
 
 	return asciiPath;
 };


### PR DESCRIPTION
Especially relevant once we use strings for filenames later.