### PR TITLE
Adding singleItem

### DIFF
--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -1,26 +1,3 @@
-/*Copyright (c) 2019 The Paradox Game Converters Project
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
-
-
-
 #include "ParserHelpers.h"
 #include "Log.h"
 #include <cctype>
@@ -30,6 +7,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
 namespace commonItems
 {
 std::string getNextLexeme(std::istream& theStream);
+std::string getNextLexemeWithNewlines(std::istream& theStream);
 }
 
 
@@ -67,6 +45,42 @@ void commonItems::ignoreItem(const std::string& unused, std::istream& theStream)
 	}
 }
 
+std::string commonItems::singleItem(const std::string& unused, std::istream& theStream)
+{
+	std::string next = getNextLexeme(theStream); // equals
+	if (next == "=")
+	{
+		next = getNextLexeme(theStream);
+	}
+	std::string toReturn = next;	
+	if (next == "{")
+	{
+		int braceDepth = 1;
+		while (true)
+		{
+			if (theStream.eof())
+			{
+				return toReturn;
+			}
+
+			std::string token = getNextLexemeWithNewlines(theStream);
+			toReturn += token;
+			if (token == "{")
+			{
+				braceDepth++;
+			}
+			else if (token == "}")
+			{
+				braceDepth--;
+				if (braceDepth == 0)
+				{
+					return toReturn;
+				}
+			}
+		}
+	}
+	return toReturn;
+}
 
 void commonItems::ignoreObject(const std::string& unused, std::istream& theStream)
 {

--- a/ParserHelpers.h
+++ b/ParserHelpers.h
@@ -1,26 +1,3 @@
-/*Copyright (c) 2018 The Paradox Game Converters Project
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.*/
-
-
-
 #ifndef PARSER_HELPERS_H
 #define PARSER_HELPERS_H
 
@@ -38,7 +15,7 @@ namespace commonItems
 void ignoreItem(const std::string& unused, std::istream& theStream);
 void ignoreObject(const std::string& unused, std::istream& theStream);
 void ignoreString(const std::string& unused, std::istream& theStream);
-
+std::string singleItem(const std::string& unused, std::istream& theStream);
 
 
 class intList: commonItems::parser

--- a/newParser.cpp
+++ b/newParser.cpp
@@ -7,6 +7,7 @@ namespace fs = std::filesystem;
 namespace commonItems
 {
 	std::string getNextLexeme(std::istream& theStream);
+	std::string getNextLexemeWithNewlines(std::istream& theStream);
 }
 
 void commonItems::parser::registerKeyword(const std::string& keyword, const parsingFunction& function)
@@ -189,6 +190,96 @@ std::string commonItems::getNextLexeme(std::istream& theStream)
 		else if (inputChar == '\"' && inQuotes)
 		{
 			toReturn += inputChar;
+			break;
+		}
+		else if (!inQuotes && std::isspace(inputChar))
+		{
+			if (!toReturn.empty()) break;
+		}
+		else if (!inQuotes && inputChar == '{')
+		{
+			if (toReturn.empty())
+			{
+				toReturn += inputChar;
+			}
+			else
+			{
+				theStream.putback('{');
+			}
+			break;
+		}
+		else if (!inQuotes && inputChar == '}')
+		{
+			if (toReturn.empty())
+			{
+				toReturn += inputChar;
+			}
+			else
+			{
+				theStream.putback('}');
+			}
+			break;
+		}
+		else if (!inQuotes && inputChar == '=')
+		{
+			if (toReturn.empty())
+			{
+				toReturn += inputChar;
+			}
+			else
+			{
+				theStream.putback('=');
+			}
+			break;
+		}
+		else
+		{
+			toReturn += inputChar;
+		}
+	}
+	return toReturn;
+}
+
+std::string commonItems::getNextLexemeWithNewlines(std::istream& theStream)
+{
+	std::string toReturn;
+
+	auto inQuotes = false;
+	while (true)
+	{
+		char inputChar;
+		theStream >> inputChar;
+		if (theStream.eof()) break;
+		if (!inQuotes && inputChar == '#')
+		{
+			std::string bitBucket;
+			std::getline(theStream, bitBucket);
+			if (!toReturn.empty()) break;
+		}
+		else if (inputChar == '\n')
+		{
+			if (!inQuotes)
+			{
+				if (!toReturn.empty()) {
+					toReturn += inputChar;
+					break;
+				}
+			}
+			else
+			{
+				// fix paradox' mistake and don't break proper names in half
+				toReturn += " ";
+			}
+		}
+		else if (inputChar == '\"' && !inQuotes && toReturn.empty())
+		{
+			inQuotes = true;
+			toReturn += inputChar;
+		}
+		else if (inputChar == '\"' && inQuotes)
+		{
+			toReturn += inputChar;
+			toReturn += '\n';
 			break;
 		}
 		else if (!inQuotes && std::isspace(inputChar))


### PR DESCRIPTION
It should do the same as ignoreItem, but return the item as string. It uses getNextLexemeWithNewlines so the indicidual lines are not pasted together, as regular lexeme grabber breaks on the newline or ignores it.