### PR TITLE
Version

### DIFF
--- a/Version.cpp
+++ b/Version.cpp
@@ -1,0 +1,109 @@
+#include "Version.h"
+#include "Log.h"
+#include "ParserHelpers.h"
+
+Version::Version(std::string version)
+{
+	int dot = version.find_first_of('.'); // the dots separating the version parts
+	firstPart = std::stoi(version.substr(0, dot));
+
+	if (dot != std::string::npos)
+	{
+		version = version.substr(dot + 1, version.size());
+		dot = version.find_first_of('.');
+		secondPart = std::stoi(version.substr(0, dot));
+
+		if (dot != std::string::npos)
+		{
+			version = version.substr(dot + 1, version.size());
+			dot = version.find_first_of('.');
+			thirdPart = std::stoi(version.substr(0, dot));
+
+			if (dot != std::string::npos)
+			{
+				version = version.substr(dot + 1, version.size());
+				dot = version.find_first_of('.');
+				fourthPart = std::stoi(version.substr(0, dot));
+			}
+		}
+	}
+}
+
+Version::Version(std::istream& theStream)
+{
+	registerKeyword("first", [this](const std::string& unused, std::istream& theStream) {
+		const commonItems::singleInt firstString(theStream);
+		firstPart = firstString.getInt();
+		});
+	registerKeyword("second", [this](const std::string& unused, std::istream& theStream) {
+		const commonItems::singleInt firstString(theStream);
+		secondPart = firstString.getInt();
+		});
+	registerKeyword("third", [this](const std::string& unused, std::istream& theStream) {
+		const commonItems::singleInt firstString(theStream);
+		thirdPart = firstString.getInt();
+		});
+	registerKeyword("forth", [this](const std::string& unused, std::istream& theStream) {
+		const commonItems::singleInt firstString(theStream);
+		fourthPart = firstString.getInt();
+		});
+	registerRegex("[a-zA-Z0-9_\\.:]+", commonItems::ignoreItem);
+
+	parseStream(theStream);
+	clearRegisteredKeywords();
+}
+
+bool Version::operator>=(const Version& rhs) const
+{
+	if (firstPart > rhs.firstPart) return true;
+	if (firstPart == rhs.firstPart && secondPart > rhs.secondPart) return true;
+	if (firstPart == rhs.firstPart && secondPart == rhs.secondPart && thirdPart > rhs.thirdPart) return true;
+	if (firstPart == rhs.firstPart && secondPart == rhs.secondPart && thirdPart == rhs.thirdPart && fourthPart >= rhs.fourthPart) return true;
+	return false;
+}
+
+bool Version::operator>(const Version& rhs) const
+{
+	if (firstPart > rhs.firstPart) return true;
+	if (firstPart == rhs.firstPart && secondPart > rhs.secondPart) return true;
+	if (firstPart == rhs.firstPart && secondPart == rhs.secondPart && thirdPart > rhs.thirdPart) return true;
+	if (firstPart == rhs.firstPart && secondPart == rhs.secondPart && thirdPart == rhs.thirdPart && fourthPart > rhs.fourthPart) return true;
+	return false;
+}
+
+bool Version::operator<(const Version& rhs) const
+{
+	if (firstPart < rhs.firstPart) return true;
+	if (firstPart == rhs.firstPart && secondPart < rhs.secondPart) return true;
+	if (firstPart == rhs.firstPart && secondPart == rhs.secondPart && thirdPart < rhs.thirdPart) return true;
+	if (firstPart == rhs.firstPart && secondPart == rhs.secondPart && thirdPart == rhs.thirdPart && fourthPart < rhs.fourthPart) return true;
+	return false;
+}
+
+bool Version::operator<=(const Version& rhs) const
+{
+	if (firstPart < rhs.firstPart) return true;
+	if (firstPart == rhs.firstPart && secondPart < rhs.secondPart) return true;
+	if (firstPart == rhs.firstPart && secondPart == rhs.secondPart && thirdPart < rhs.thirdPart) return true;
+	if (firstPart == rhs.firstPart && secondPart == rhs.secondPart && thirdPart == rhs.thirdPart && fourthPart <= rhs.fourthPart) return true;
+	return false;
+}
+
+bool Version::operator==(const Version& rhs) const
+{
+	return firstPart == rhs.firstPart && secondPart == rhs.secondPart && thirdPart == rhs.thirdPart && fourthPart == rhs.fourthPart;
+}
+
+bool Version::operator!=(const Version& rhs) const
+{
+	return firstPart != rhs.firstPart || secondPart != rhs.secondPart || thirdPart != rhs.thirdPart || fourthPart != rhs.fourthPart;
+}
+
+std::ostream& operator<<(std::ostream& out, const Version& version)
+{
+	out << version.firstPart << '.';
+	out << version.secondPart << '.';
+	out << version.thirdPart << '.';
+	out << version.fourthPart;
+	return out;
+}

--- a/Version.h
+++ b/Version.h
@@ -1,0 +1,39 @@
+#ifndef VERSION_H
+#define VERSION_H
+
+#include "newParser.h"
+#include <ostream>
+#include <string>
+
+class Version : commonItems::parser
+{
+public:
+	Version() = default;
+	Version(const Version&) = default;
+	Version(Version&&) = default;
+	Version& operator=(const Version&) = default;
+	Version& operator=(Version&&) = default;
+	~Version() = default;
+
+	explicit Version(std::string version);
+	explicit Version(std::istream& theStream);
+
+	bool operator>=(const Version& rhs) const;
+	bool operator>(const Version& rhs) const;
+	bool operator<(const Version& rhs) const;
+	bool operator<=(const Version& rhs) const;
+	bool operator==(const Version& rhs) const;
+	bool operator!=(const Version& rhs) const;
+
+	friend std::ostream& operator<<(std::ostream&, const Version& version);
+
+private:
+	int firstPart = 0;
+	int secondPart = 0;
+	int thirdPart = 0;
+	int fourthPart = 0;
+};
+
+std::ostream& operator<<(std::ostream&, const Version& version);
+
+#endif // VERSION_H


### PR DESCRIPTION
Used by CK2ToEU4, ImperatorToCK3 and EU4ToVic2 (named "EU4Version" and with EU4 namespace).

I included a fix for this:
![image](https://user-images.githubusercontent.com/29546927/79209010-1fd23580-7e43-11ea-8d03-4b598150103c.png)
