### PR TITLE
Path normalization to commons.

### DIFF
--- a/CommonFunctions.cpp
+++ b/CommonFunctions.cpp
@@ -1,5 +1,6 @@
 #include "CommonFunctions.h"
 #include <algorithm>
+#include "OSCompatibilityLayer.h"
 
 std::string trimPath(const std::string& fileName)
 {
@@ -60,5 +61,14 @@ std::string cardinalToRoman(int number)
 		}
 		i--;
 	}
+	return toReturn;
+}
+
+std::string normalizeStringPath(const std::string& stringPath)
+{
+	std::string toReturn = Utils::normalizeUTF8Path(stringPath);
+	toReturn = replaceCharacter(toReturn, '-');
+	toReturn = replaceCharacter(toReturn, ' ');
+
 	return toReturn;
 }

--- a/CommonFunctions.h
+++ b/CommonFunctions.h
@@ -8,5 +8,6 @@ std::string replaceCharacter(std::string fileName, char character);
 std::string cardinalToOrdinal(int cardinal);
 [[deprecated("Use cardinalToOrdinal (lower case 'c')")]] inline std::string CardinalToOrdinal(const int cardinal) { return cardinalToOrdinal(cardinal); }
 std::string cardinalToRoman(int number);
+std::string normalizeStringPath(const std::string& stringPath);
 
 #endif // COMMON_FUNCTIONS_H

--- a/LinuxUtils.cpp
+++ b/LinuxUtils.cpp
@@ -613,8 +613,4 @@ std::string convertToUTF8(const std::wstring& input)
 	return ConvertString<wstring, string>("wchar_t", "UTF-8", input);
 }
 
-std::string normalizeUTF8Path(const std::string& utf_8_path)
-{
-	return utf_8_path;
-};
 } // namespace Utils

--- a/OSCommonLayer.cpp
+++ b/OSCommonLayer.cpp
@@ -120,4 +120,21 @@ bool DeleteFolder(const std::string& folder)
 	return false;
 }
 
+std::string normalizeUTF8Path(const std::string& utf_8_path)
+{
+	std::string asciiPath = convertUTF8ToASCII(utf_8_path);
+	std::replace(asciiPath.begin(), asciiPath.end(), '/', '_');
+	std::replace(asciiPath.begin(), asciiPath.end(), '\\', '_');
+	std::replace(asciiPath.begin(), asciiPath.end(), ':', '_');
+	std::replace(asciiPath.begin(), asciiPath.end(), '*', '_');
+	std::replace(asciiPath.begin(), asciiPath.end(), '?', '_');
+	std::replace(asciiPath.begin(), asciiPath.end(), '\"', '_');
+	std::replace(asciiPath.begin(), asciiPath.end(), '<', '_');
+	std::replace(asciiPath.begin(), asciiPath.end(), '>', '_');
+	std::replace(asciiPath.begin(), asciiPath.end(), '|', '_');
+	asciiPath.erase(std::remove(asciiPath.begin(), asciiPath.end(), '\t'), asciiPath.end());
+
+	return asciiPath;
+}
+	
 } // namespace Utils

--- a/WinUtils.cpp
+++ b/WinUtils.cpp
@@ -226,25 +226,6 @@ std::string convertToUTF8(const std::wstring& input)
 	return convertUTF16ToUTF8(input);
 }
 
-
-std::string normalizeUTF8Path(const std::string& utf_8_path)
-{
-	std::string asciiPath = convertUTF8ToASCII(utf_8_path);
-	std::replace(asciiPath.begin(), asciiPath.end(), '/', '_');
-	std::replace(asciiPath.begin(), asciiPath.end(), '\\', '_');
-	std::replace(asciiPath.begin(), asciiPath.end(), ':', '_');
-	std::replace(asciiPath.begin(), asciiPath.end(), '*', '_');
-	std::replace(asciiPath.begin(), asciiPath.end(), '?', '_');
-	std::replace(asciiPath.begin(), asciiPath.end(), '\"', '_');
-	std::replace(asciiPath.begin(), asciiPath.end(), '<', '_');
-	std::replace(asciiPath.begin(), asciiPath.end(), '>', '_');
-	std::replace(asciiPath.begin(), asciiPath.end(), '|', '_');
-	asciiPath.erase(std::remove(asciiPath.begin(), asciiPath.end(), '\t'), asciiPath.end());
-
-	return asciiPath;
-};
-
-
 void WriteToConsole(LogLevel level, const std::string& logMessage)
 {
 	if (level == LogLevel::Debug)


### PR DESCRIPTION
- Dropping linux version of normalizeUTF8Path so both linux and windows would behave identically.
- moving normalizeStringPath into commons, since it's related.