### PR TITLE
Renaming CurrentDirectory

### DIFF
--- a/OSCommonLayer.cpp
+++ b/OSCommonLayer.cpp
@@ -18,7 +18,7 @@ bool TryCreateFolder(const std::string& path)
 	return false;
 }
 
-std::string GetCurrentDirectory()
+std::string GetCurrentDirectoryString()
 {
 	return fs::current_path().string();
 }

--- a/OSCompatibilityLayer.h
+++ b/OSCompatibilityLayer.h
@@ -68,7 +68,7 @@ GetAllFilesInFolderRecursive(const std::string& path, std::set<std::string>& fil
 	fileNames = GetAllFilesInFolderRecursive(path);
 }
 
-std::string GetCurrentDirectory();
+std::string GetCurrentDirectoryString();
 
 bool TryCreateFolder(const std::string& path);
 bool TryCopyFile(const std::string& sourcePath, const std::string& destPath);


### PR DESCRIPTION
- avoid collision with windows system function call of same name.