### PR TITLE
Color fixes:

### DIFF
--- a/Color.cpp
+++ b/Color.cpp
@@ -7,8 +7,7 @@
 #include <random>
 #include <regex>
 #include <sstream>
-
-
+#include "StringUtils.h"
 
 bool commonItems::Color::operator==(const Color& rhs) const
 {
@@ -33,7 +32,9 @@ std::string commonItems::Color::outputHex() const
 {
 	std::stringstream output;
 	output << "= hex { ";
-	output << std::hex << rgbComponents[0] << rgbComponents[1] << rgbComponents[2];
+	output << std::setw(2) << std::setfill('0') << std::hex << rgbComponents[0];
+	output << std::setw(2) << std::setfill('0') << std::hex << rgbComponents[1];
+	output << std::setw(2) << std::setfill('0') << std::hex << rgbComponents[2];
 	output << " }";
 	return output.str();
 }
@@ -203,7 +204,9 @@ commonItems::Color commonItems::Color::Factory::getColor(std::istream& theStream
 {
 	getNextTokenWithoutMatching(theStream); // equals sign
 
-	const auto token = getNextTokenWithoutMatching(theStream);
+	auto token = getNextTokenWithoutMatching(theStream);
+	if (token)
+		token = stringutils::remQuotes(*token);
 	if (token == "rgb")
 	{
 		const auto rgb = intList{theStream}.getInts();

--- a/tests/ColorTests.cpp
+++ b/tests/ColorTests.cpp
@@ -453,6 +453,26 @@ TEST(Color_Tests, ColorCanBeInitializedFromStreamWithName)
 	ASSERT_NEAR(0.5f, v, 0.01);
 }
 
+TEST(Color_Tests, ColorCanBeInitializedFromQuotedStreamWithName)
+{
+	auto colorFactory = commonItems::Color::Factory();
+	colorFactory.addNamedColor("dark_moderate_cyan", commonItems::Color(std::array<int, 3>{64, 128, 128}));
+
+	std::stringstream input;
+	input << "= \"dark_moderate_cyan\"";
+	const auto testColor = colorFactory.getColor(input);
+
+	auto [r, g, b] = testColor.getRgbComponents();
+	ASSERT_EQ(64, r);
+	ASSERT_EQ(128, g);
+	ASSERT_EQ(128, b);
+
+	auto [h, s, v] = testColor.getHsvComponents();
+	ASSERT_NEAR(0.5f, h, 0.01);
+	ASSERT_NEAR(0.5f, s, 0.01);
+	ASSERT_NEAR(0.5f, v, 0.01);
+}
+
 
 TEST(Color_Tests, ColorInitializingRequiresCachedColorWhenUsingName)
 {
@@ -619,6 +639,15 @@ TEST(Color_Tests, ColorCanBeOutputInHexColorSpace)
 	ASSERT_EQ("= hex { 408080 }", output.str());
 }
 
+TEST(Color_Tests, ColorCanBeOutputInHexColorSpacePreservingZeroes)
+{
+	const commonItems::Color testColor(std::array<int, 3>{0, 0, 0});
+
+	std::stringstream output;
+	output << testColor.outputHex();
+
+	ASSERT_EQ("= hex { 000000 }", output.str());
+}
 
 TEST(Color_Tests, ColorCanBeOutputInHsvColorSpace)
 {


### PR DESCRIPTION
- hex output will preserve leading zeroes
- quoted strings can be used as color names.