### PR TITLE
Minor tweaks

### DIFF
--- a/OSCompatibilityLayer.h
+++ b/OSCompatibilityLayer.h
@@ -25,7 +25,7 @@
 #define sprintf_s sprintf_s_Linux
 void sprintf_s_Linux(char* __restrict __s, size_t __maxlen, const char* __restrict __format, ...);
 
-// See sprintf_s_LInux
+// See sprintf_s_Linux
 #define strcpy_s strcpy_s_Linux
 void strcpy_s_Linux(char* __restrict __dest, const char* __restrict __src);
 
@@ -98,7 +98,7 @@ std::string convert8859_15ToUTF8(const std::string& input);
 std::wstring convert8859_15ToUTF16(const std::string& input);
 std::string convertWin1252ToASCII(const std::string& Win1252);
 std::string convertWin1252ToUTF8(const std::string& Win1252);
-std::string convertWin1250ToUTF8(const std::string& Win1252);
+std::string convertWin1250ToUTF8(const std::string& Win1250);
 std::wstring convertWin1252ToUTF16(const std::string& Win1252);
 std::wstring convertWin1250ToUTF16(const std::string& Win1250);
 std::wstring convertUTF8ToUTF16(const std::string& UTF8);

--- a/WinUtils.cpp
+++ b/WinUtils.cpp
@@ -168,28 +168,28 @@ std::wstring convert8859_15ToUTF16(const std::string& input)
 }
 
 
-std::string convertWin1252ToASCII(const std::string& input)
+std::string convertWin1252ToASCII(const std::string& Win1252)
 {
-	return convertUTF8ToASCII(convertWin1252ToUTF8(input));
+	return convertUTF8ToASCII(convertWin1252ToUTF8(Win1252));
 }
 
 
-std::string convertWin1252ToUTF8(const std::string& input)
+std::string convertWin1252ToUTF8(const std::string& Win1252)
 {
-	return UTF16ToUTF8(convertWin1252ToUTF16(input));
+	return UTF16ToUTF8(convertWin1252ToUTF16(Win1252));
 }
 
-std::string convertWin1250ToUTF8(const std::string& input)
+std::string convertWin1250ToUTF8(const std::string& Win1250)
 {
-	return UTF16ToUTF8(convertWin1250ToUTF16(input));
+	return UTF16ToUTF8(convertWin1250ToUTF16(Win1250));
 }
 
-std::wstring convertWin1250ToUTF16(const std::string& input)
+std::wstring convertWin1250ToUTF16(const std::string& Win1250)
 {
-	const int requiredSize = MultiByteToWideChar(1250, MB_PRECOMPOSED, input.c_str(), -1, nullptr, 0);
+	const int requiredSize = MultiByteToWideChar(1250, MB_PRECOMPOSED, Win1250.c_str(), -1, nullptr, 0);
 	auto* wideKeyArray = new wchar_t[requiredSize];
 
-	if (0 == MultiByteToWideChar(1250, MB_PRECOMPOSED, input.c_str(), -1, wideKeyArray, requiredSize))
+	if (0 == MultiByteToWideChar(1250, MB_PRECOMPOSED, Win1250.c_str(), -1, wideKeyArray, requiredSize))
 	{
 		Log(LogLevel::Error) << "Could not translate string to UTF-16 - " << GetLastErrorString();
 	}
@@ -200,12 +200,12 @@ std::wstring convertWin1250ToUTF16(const std::string& input)
 	return returnable;
 }
 
-std::wstring convertWin1252ToUTF16(const std::string& input)
+std::wstring convertWin1252ToUTF16(const std::string& Win1252)
 {
-	const int requiredSize = MultiByteToWideChar(1252, MB_PRECOMPOSED, input.c_str(), -1, nullptr, 0);
+	const int requiredSize = MultiByteToWideChar(1252, MB_PRECOMPOSED, Win1252.c_str(), -1, nullptr, 0);
 	auto* wideKeyArray = new wchar_t[requiredSize];
 
-	if (0 == MultiByteToWideChar(1252, MB_PRECOMPOSED, input.c_str(), -1, wideKeyArray, requiredSize))
+	if (0 == MultiByteToWideChar(1252, MB_PRECOMPOSED, Win1252.c_str(), -1, wideKeyArray, requiredSize))
 	{
 		Log(LogLevel::Error) << "Could not translate string to UTF-16 - " << GetLastErrorString();
 	}

--- a/tests/CommonItemsTests.sln.DotSettings
+++ b/tests/CommonItemsTests.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=wstring/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/tests/CommonItemsTests.vcxproj
+++ b/tests/CommonItemsTests.vcxproj
@@ -139,7 +139,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>false</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;_CRT_SECURE_NO_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <OmitFramePointers>false</OmitFramePointers>


### PR DESCRIPTION
- Fixed a typo
- Fixed parameter names not matching declaration
- Fixed parameter name in `convertWin1250ToUTF8`
- Disabled `localtime` deprecation warning