### PR TITLE
Purge of "unused"

### DIFF
--- a/GameVersion.cpp
+++ b/GameVersion.cpp
@@ -46,16 +46,16 @@ GameVersion::GameVersion(std::istream& theStream)
 
 void GameVersion::registerKeys()
 {
-	registerKeyword("first", [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("first", [this](std::istream& theStream) {
 		firstPart = commonItems::singleInt(theStream).getInt();
 	});
-	registerKeyword("second", [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("second", [this](std::istream& theStream) {
 		secondPart = commonItems::singleInt(theStream).getInt();
 	});
-	registerKeyword("third", [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("third", [this](std::istream& theStream) {
 		thirdPart = commonItems::singleInt(theStream).getInt();
 	});
-	registerKeyword("forth", [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("forth", [this](std::istream& theStream) {
 		fourthPart = commonItems::singleInt(theStream).getInt();
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);
@@ -139,16 +139,16 @@ std::ostream& operator<<(std::ostream& out, const GameVersion& version)
 
 GameVersion::Factory::Factory()
 {
-	registerKeyword("first", [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("first", [this](std::istream& theStream) {
 		firstPart = commonItems::singleInt(theStream).getInt();
 	});
-	registerKeyword("second", [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("second", [this](std::istream& theStream) {
 		secondPart = commonItems::singleInt(theStream).getInt();
 	});
-	registerKeyword("third", [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("third", [this](std::istream& theStream) {
 		thirdPart = commonItems::singleInt(theStream).getInt();
 	});
-	registerKeyword("forth", [this](const std::string& unused, std::istream& theStream) {
+	registerKeyword("forth", [this](std::istream& theStream) {
 		fourthPart = commonItems::singleInt(theStream).getInt();
 	});
 	registerRegex(commonItems::catchallRegex, commonItems::ignoreItem);

--- a/Parser.cpp
+++ b/Parser.cpp
@@ -43,12 +43,6 @@ void commonItems::parser::registerRegex(const std::string& keyword, const parsin
 }
 
 
-void commonItems::parser::registerRegex(const std::string& keyword, const parsingFunctionStreamOnly& function)
-{
-	generatedRegexesStreamOnly.emplace_back(std::make_pair(std::regex(keyword), function));
-}
-
-
 void commonItems::parser::parseStream(std::istream& theStream)
 {
 	auto braceDepth = 0;
@@ -124,7 +118,6 @@ void commonItems::parser::clearRegisteredKeywords() noexcept
 	std::map<std::string, parsingFunction>().swap(registeredKeywordStrings);
 	std::map<std::string, parsingFunctionStreamOnly>().swap(registeredKeywordStringsStreamOnly);
 	std::vector<std::pair<std::regex, parsingFunction>>().swap(generatedRegexes);
-	std::vector<std::pair<std::regex, parsingFunctionStreamOnly>>().swap(generatedRegexesStreamOnly);
 }
 
 
@@ -207,15 +200,6 @@ inline bool commonItems::parser::tryToMatchAgainstRegexes(const std::string& toR
 			return true;
 		}
 	}
-	for (const auto& [regex, parsingFunction]: generatedRegexesStreamOnly)
-	{
-		std::smatch match;
-		if (std::regex_match(toReturn, match, regex))
-		{
-			parsingFunction(theStream);
-			return true;
-		}
-	}
 	if (isLexemeQuoted)
 	{
 		for (const auto& [regex, parsingFunction]: generatedRegexes)
@@ -224,15 +208,6 @@ inline bool commonItems::parser::tryToMatchAgainstRegexes(const std::string& toR
 			if (std::regex_match(strippedLexeme, match, regex))
 			{
 				parsingFunction(toReturn, theStream);
-				return true;
-			}
-		}
-		for (const auto& [regex, parsingFunction]: generatedRegexesStreamOnly)
-		{
-			std::smatch match;
-			if (std::regex_match(strippedLexeme, match, regex))
-			{
-				parsingFunction(theStream);
 				return true;
 			}
 		}

--- a/Parser.cpp
+++ b/Parser.cpp
@@ -29,6 +29,8 @@ void commonItems::parser::registerKeyword(const std::string& keyword, const pars
 {
 	registeredKeywordStrings.insert(std::make_pair(keyword, function));
 }
+
+
 void commonItems::parser::registerKeyword(const std::string& keyword, const parsingFunctionStreamOnly& function)
 {
 	registeredKeywordStringsStreamOnly.insert(std::make_pair(keyword, function));
@@ -39,6 +41,8 @@ void commonItems::parser::registerRegex(const std::string& keyword, const parsin
 {
 	generatedRegexes.emplace_back(std::make_pair(std::regex(keyword), function));
 }
+
+
 void commonItems::parser::registerRegex(const std::string& keyword, const parsingFunctionStreamOnly& function)
 {
 	generatedRegexesStreamOnly.emplace_back(std::make_pair(std::regex(keyword), function));

--- a/Parser.h
+++ b/Parser.h
@@ -53,11 +53,11 @@ class parser
 		 bool isLexemeQuoted,
 		 std::istream& theStream);
 
-	std::map<std::string, parsingFunction> registeredKeywordStrings;
 	std::map<std::string, parsingFunctionStreamOnly> registeredKeywordStringsStreamOnly;
+	std::map<std::string, parsingFunction> registeredKeywordStrings;
 
-	std::vector<std::pair<std::regex, parsingFunction>> generatedRegexes;
 	std::vector<std::pair<std::regex, parsingFunctionStreamOnly>> generatedRegexesStreamOnly;
+	std::vector<std::pair<std::regex, parsingFunction>> generatedRegexes;
 };
 
 } // namespace commonItems

--- a/Parser.h
+++ b/Parser.h
@@ -14,6 +14,7 @@ namespace commonItems
 {
 
 typedef std::function<void(const std::string&, std::istream&)> parsingFunction;
+typedef std::function<void(std::istream&)> parsingFunctionStreamOnly;
 
 
 void absorbBOM(std::istream& theStream);
@@ -29,7 +30,9 @@ class parser
 	parser& operator=(const parser&) = default;
 	parser& operator=(parser&&) = default;
 
-	void registerKeyword(const std::string& keyword, const parsingFunction& function);
+	void registerKeyword(const std::string& keyword, const parsingFunctionStreamOnly& function);
+	void registerKeyword(const std::string& keyword, const parsingFunction& function); // for the few keywords that need to be returned
+	void registerRegex(const std::string& keyword, const parsingFunctionStreamOnly& function);
 	void registerRegex(const std::string& keyword, const parsingFunction& function);
 	void clearRegisteredKeywords() noexcept;
 
@@ -41,8 +44,20 @@ class parser
 
 
   private:
+	inline bool tryToMatchAgainstKeywords(const std::string& toReturn,
+		 const std::string& strippedLexeme,
+		 bool isLexemeQuoted,
+		 std::istream& theStream);
+	inline bool tryToMatchAgainstRegexes(const std::string& toReturn,
+		 const std::string& strippedLexeme,
+		 bool isLexemeQuoted,
+		 std::istream& theStream);
+
 	std::map<std::string, parsingFunction> registeredKeywordStrings;
+	std::map<std::string, parsingFunctionStreamOnly> registeredKeywordStringsStreamOnly;
+
 	std::vector<std::pair<std::regex, parsingFunction>> generatedRegexes;
+	std::vector<std::pair<std::regex, parsingFunctionStreamOnly>> generatedRegexesStreamOnly;
 };
 
 } // namespace commonItems

--- a/Parser.h
+++ b/Parser.h
@@ -32,7 +32,6 @@ class parser
 
 	void registerKeyword(const std::string& keyword, const parsingFunctionStreamOnly& function);
 	void registerKeyword(const std::string& keyword, const parsingFunction& function); // for the few keywords that need to be returned
-	void registerRegex(const std::string& keyword, const parsingFunctionStreamOnly& function);
 	void registerRegex(const std::string& keyword, const parsingFunction& function);
 	void clearRegisteredKeywords() noexcept;
 
@@ -56,7 +55,6 @@ class parser
 	std::map<std::string, parsingFunctionStreamOnly> registeredKeywordStringsStreamOnly;
 	std::map<std::string, parsingFunction> registeredKeywordStrings;
 
-	std::vector<std::pair<std::regex, parsingFunctionStreamOnly>> generatedRegexesStreamOnly;
 	std::vector<std::pair<std::regex, parsingFunction>> generatedRegexes;
 };
 

--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -10,7 +10,7 @@ namespace commonItems
 
 std::string getNextLexeme(std::istream& theStream);
 
-void ignoreItem(const std::string& unused, std::istream& theStream)
+void ignoreItem(std::istream& theStream)
 {
 	auto next = getNextLexeme(theStream);
 	if (next == "=")
@@ -51,7 +51,7 @@ void ignoreItem(const std::string& unused, std::istream& theStream)
 	}
 }
 
-void ignoreObject(const std::string& unused, std::istream& theStream)
+void ignoreObject(std::istream& theStream)
 {
 	auto braceDepth = 0;
 	while (true)
@@ -78,7 +78,7 @@ void ignoreObject(const std::string& unused, std::istream& theStream)
 }
 
 
-void ignoreString(const std::string& unused, std::istream& theStream)
+void ignoreString(std::istream& theStream)
 {
 	singleString ignore(theStream);
 }
@@ -329,7 +329,7 @@ blobList::blobList(std::istream& theStream)
 
 stringList::stringList(std::istream& theStream)
 {
-	registerKeyword(R"("")", [](const std::string& unused, std::istream& theStream) {
+	registerKeyword(R"("")", [](std::istream& theStream) {
 	});
 	registerRegex(R"([^[:s:]^=^\{^\}^\"]+)", [this](const std::string& theString, std::istream& theStream) {
 		strings.push_back(theString);
@@ -436,7 +436,7 @@ stringsOfItems::stringsOfItems(std::istream& theStream)
 stringsOfItemNames::stringsOfItemNames(std::istream& theStream)
 {
 	registerRegex(catchallRegex, [this](const std::string& itemName, std::istream& theStream) {
-		ignoreItem(itemName, theStream);
+		ignoreItem(theStream);
 		theStrings.push_back(itemName);
 	});
 

--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -10,7 +10,7 @@ namespace commonItems
 
 std::string getNextLexeme(std::istream& theStream);
 
-void ignoreItem(std::istream& theStream)
+void ignoreItem(const std::string& unused, std::istream& theStream)
 {
 	auto next = getNextLexeme(theStream);
 	if (next == "=")
@@ -51,7 +51,7 @@ void ignoreItem(std::istream& theStream)
 	}
 }
 
-void ignoreObject(std::istream& theStream)
+void ignoreObject(const std::string& unused, std::istream& theStream)
 {
 	auto braceDepth = 0;
 	while (true)
@@ -78,7 +78,7 @@ void ignoreObject(std::istream& theStream)
 }
 
 
-void ignoreString(std::istream& theStream)
+void ignoreString(const std::string& unused, std::istream& theStream)
 {
 	singleString ignore(theStream);
 }
@@ -436,7 +436,7 @@ stringsOfItems::stringsOfItems(std::istream& theStream)
 stringsOfItemNames::stringsOfItemNames(std::istream& theStream)
 {
 	registerRegex(catchallRegex, [this](const std::string& itemName, std::istream& theStream) {
-		ignoreItem(theStream);
+		ignoreItem(itemName, theStream);
 		theStrings.push_back(itemName);
 	});
 

--- a/ParserHelpers.h
+++ b/ParserHelpers.h
@@ -12,9 +12,9 @@ namespace commonItems
 // in the parser.
 constexpr char catchallRegex[] = R"([^=^{^}]+|\".+\")";
 
-void ignoreItem(const std::string& unused, std::istream& theStream);
-void ignoreObject(const std::string& unused, std::istream& theStream);
-void ignoreString(const std::string& unused, std::istream& theStream);
+void ignoreItem(std::istream& theStream);
+void ignoreObject(std::istream& theStream);
+void ignoreString(std::istream& theStream);
 
 class intList: parser
 {

--- a/ParserHelpers.h
+++ b/ParserHelpers.h
@@ -12,9 +12,9 @@ namespace commonItems
 // in the parser.
 constexpr char catchallRegex[] = R"([^=^{^}]+|\".+\")";
 
-void ignoreItem(std::istream& theStream);
-void ignoreObject(std::istream& theStream);
-void ignoreString(std::istream& theStream);
+void ignoreItem(const std::string& unused, std::istream& theStream);
+void ignoreObject(const std::string& unused, std::istream& theStream);
+void ignoreString(const std::string& unused, std::istream& theStream);
 
 class intList: parser
 {

--- a/tests/ColorTests.cpp
+++ b/tests/ColorTests.cpp
@@ -565,7 +565,7 @@ class foo: commonItems::parser
   public:
 	explicit foo(std::istream& theStream)
 	{
-		registerKeyword("color", [this](const std::string& unused, std::istream& theStream) {
+		registerKeyword("color", [this](std::istream& theStream) {
 			color = commonItems::Color::Factory{}.getColor(theStream);
 		});
 		parseStream(theStream);

--- a/tests/ParserHelperTests.cpp
+++ b/tests/ParserHelperTests.cpp
@@ -7,7 +7,7 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresSimpleText)
 {
 	std::stringstream input{"ignore_me More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem(input);
+	commonItems::ignoreItem("unused", input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -19,7 +19,7 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresAssignedText)
 {
 	std::stringstream input{"= ignore_me More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem(input);
+	commonItems::ignoreItem("unused", input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -31,7 +31,7 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresBracedItem)
 {
 	std::stringstream input{"{ { ignore_me } } More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem(input);
+	commonItems::ignoreItem("unused", input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -43,7 +43,7 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresAssignedBracedItem)
 {
 	std::stringstream input{"= { { ignore_me } } More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem(input);
+	commonItems::ignoreItem("unused", input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -55,7 +55,7 @@ TEST(ParserHelper_Tests, IgnoreObjectIgnoresNextItem)
 {
 	std::stringstream input{"ignore_me More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem(input);
+	commonItems::ignoreItem("unused", input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -67,7 +67,7 @@ TEST(ParserHelper_Tests, IgnoreObjectIgnoresWholeBracedItem)
 {
 	std::stringstream input{"{ { ignore_me } } More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem(input);
+	commonItems::ignoreItem("unused", input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -79,7 +79,7 @@ TEST(ParserHelper_Tests, IgnoreStringIgnoresNextItem)
 {
 	std::stringstream input{"ignore_me More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem(input);
+	commonItems::ignoreItem("unused", input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -91,7 +91,7 @@ TEST(ParserHelper_Tests, IgnoreStringIgnoresWholeQuoation)
 {
 	std::stringstream input{R"("ignore_me More" text)"};
 	input >> std::noskipws;
-	commonItems::ignoreItem(input);
+	commonItems::ignoreItem("unused", input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -804,8 +804,8 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresSimpleColorWithColorSpace)
 	std::stringstream input2{"hsv {0.1 1.0 0.6} More text"};
 	input >> std::noskipws;
 	input2 >> std::noskipws;
-	commonItems::ignoreItem(input);
-	commonItems::ignoreItem(input2);
+	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem("unused", input2);
 
 	char buffer[256];
 	char buffer2[256];
@@ -822,8 +822,8 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresAssignedColorWithColorSpace)
 	std::stringstream input2{"= hsv {0.1 1.0 0.6} More text"};
 	input >> std::noskipws;
 	input2 >> std::noskipws;
-	commonItems::ignoreItem(input);
-	commonItems::ignoreItem(input2);
+	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem("unused", input2);
 
 	char buffer[256];
 	char buffer2[256];
@@ -840,8 +840,8 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresRgbAndHsvStringsWithoutBreakingParsing
 	std::stringstream input2{"= hsv next_parameter = 420 More text"};
 	input >> std::noskipws;
 	input2 >> std::noskipws;
-	commonItems::ignoreItem(input);
-	commonItems::ignoreItem(input2);
+	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem("unused", input2);
 
 	char buffer[256];
 	char buffer2[256];
@@ -858,8 +858,8 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresQuotedRgbAndHsvStringsWithoutBreakingP
 	std::stringstream input2{"= \"hsv\" next_parameter = 420 More text"};
 	input >> std::noskipws;
 	input2 >> std::noskipws;
-	commonItems::ignoreItem(input);
-	commonItems::ignoreItem(input2);
+	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem("unused", input2);
 
 	char buffer[256];
 	char buffer2[256];

--- a/tests/ParserHelperTests.cpp
+++ b/tests/ParserHelperTests.cpp
@@ -7,7 +7,7 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresSimpleText)
 {
 	std::stringstream input{"ignore_me More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -19,7 +19,7 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresAssignedText)
 {
 	std::stringstream input{"= ignore_me More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -31,7 +31,7 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresBracedItem)
 {
 	std::stringstream input{"{ { ignore_me } } More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -43,7 +43,7 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresAssignedBracedItem)
 {
 	std::stringstream input{"= { { ignore_me } } More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -55,7 +55,7 @@ TEST(ParserHelper_Tests, IgnoreObjectIgnoresNextItem)
 {
 	std::stringstream input{"ignore_me More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -67,7 +67,7 @@ TEST(ParserHelper_Tests, IgnoreObjectIgnoresWholeBracedItem)
 {
 	std::stringstream input{"{ { ignore_me } } More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -79,7 +79,7 @@ TEST(ParserHelper_Tests, IgnoreStringIgnoresNextItem)
 {
 	std::stringstream input{"ignore_me More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -91,7 +91,7 @@ TEST(ParserHelper_Tests, IgnoreStringIgnoresWholeQuoation)
 {
 	std::stringstream input{R"("ignore_me More" text)"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -731,7 +731,7 @@ TEST(ParserHelper_Tests, ParseStreamSkipsMissingKeyInBraces)
 	  public:
 		explicit TestClass(std::istream& theStream)
 		{
-			registerKeyword("test", [this](const std::string& unused, std::istream& theStream) {
+			registerKeyword("test", [this](std::istream& theStream) {
 				const commonItems::singleString testStr(theStream);
 				test = testStr.getString() == "yes";
 			});
@@ -804,8 +804,8 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresSimpleColorWithColorSpace)
 	std::stringstream input2{"hsv {0.1 1.0 0.6} More text"};
 	input >> std::noskipws;
 	input2 >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
-	commonItems::ignoreItem("unused", input2);
+	commonItems::ignoreItem(input);
+	commonItems::ignoreItem(input2);
 
 	char buffer[256];
 	char buffer2[256];
@@ -822,8 +822,8 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresAssignedColorWithColorSpace)
 	std::stringstream input2{"= hsv {0.1 1.0 0.6} More text"};
 	input >> std::noskipws;
 	input2 >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
-	commonItems::ignoreItem("unused", input2);
+	commonItems::ignoreItem(input);
+	commonItems::ignoreItem(input2);
 
 	char buffer[256];
 	char buffer2[256];
@@ -840,8 +840,8 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresRgbAndHsvStringsWithoutBreakingParsing
 	std::stringstream input2{"= hsv next_parameter = 420 More text"};
 	input >> std::noskipws;
 	input2 >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
-	commonItems::ignoreItem("unused", input2);
+	commonItems::ignoreItem(input);
+	commonItems::ignoreItem(input2);
 
 	char buffer[256];
 	char buffer2[256];
@@ -858,8 +858,8 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresQuotedRgbAndHsvStringsWithoutBreakingP
 	std::stringstream input2{"= \"hsv\" next_parameter = 420 More text"};
 	input >> std::noskipws;
 	input2 >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
-	commonItems::ignoreItem("unused", input2);
+	commonItems::ignoreItem(input);
+	commonItems::ignoreItem(input2);
 
 	char buffer[256];
 	char buffer2[256];


### PR DESCRIPTION
- Added `typedef std::function<void(std::istream&)> parsingFunctionStreamOnly;` which should be used instead of
`typedef std::function<void(const std::string&, std::istream&)> parsingFunction;` when we don't need the `toReturn` value (which is the case for virtually all the registerKeyword usages and some registerRegex ones).
- Moved big parts of the `getNextToken` function into inline `tryToMatchAgainstRegexes` and `tryToMatchAgainstKeywords` functions to make the `getNextToken` logic clear at first glance.
- As a positive side effect, the `unused` parameter could be removed from ignoreItem, ignoreObject and ignoreString. **This part causes a minor backward compatibility problem, which I'm, as usual, ready to take care of for the modern converters.**