### PR TITLE
One vector for regexes and matchers

### DIFF
--- a/CommonRegexes.h
+++ b/CommonRegexes.h
@@ -8,17 +8,17 @@ namespace commonItems
 // catchall:
 //		We grab everything that's NOT =, { or }, OR we grab everything within quotes, except newlines, which we already drop
 //		in the parser.
-static inline const char* catchallRegex = R"([^=^{^}]+|\".+\")";
+static inline const char* catchallRegex = R"([^=^{^}]+|".+")";
 
 // numbers
 static inline const char* integerRegex = R"(-?\d+)";
-static inline const char* quotedIntegerRegex = R"(\"-?\d+\")";
+static inline const char* quotedIntegerRegex = R"("-?\d+")";
 static inline const char* floatRegex = R"(-?\d+(.\d+)?)";
-static inline const char* quotedFloatRegex = R"(\"-?\d+(.\d+)?\")";
+static inline const char* quotedFloatRegex = R"("-?\d+(.\d+)?")";
 
 // strings
 static inline const char* stringRegex = R"([^[:s:]^=^\{^\}^\"]+)";
-static inline const char* quotedStringRegex = R"(\"[^\n^=^\{^\}^\"]+\")";
+static inline const char* quotedStringRegex = R"("[^\n^=^\{^\}^\"]+")";
 
 
 // compile time regexes, cool stuff

--- a/Parser.cpp
+++ b/Parser.cpp
@@ -275,7 +275,7 @@ std::optional<std::string> commonItems::parser::getNextToken(std::istream& theSt
 		// regexes and matchers
 		if (!matched)
 		{
-			for (const auto& registered: registeredThings)
+			for (const auto& registered: registeredRegexesAndMatchers)
 			{
 				if (registered->match(toReturn, theStream))
 				{
@@ -285,7 +285,7 @@ std::optional<std::string> commonItems::parser::getNextToken(std::istream& theSt
 			}
 			if (!matched && isLexemeQuoted)
 			{
-				for (const auto& registered: registeredThings)
+				for (const auto& registered: registeredRegexesAndMatchers)
 				{
 					if (registered->matchStripped(toReturn, strippedLexeme, theStream))
 					{

--- a/Parser.h
+++ b/Parser.h
@@ -110,7 +110,7 @@ class parser
 	std::map<std::string, parsingFunctionStreamOnly> registeredKeywordStringsStreamOnly;
 	std::map<std::string, parsingFunction> registeredKeywordStrings;
 
-	std::vector<std::unique_ptr<registeredAnything>> registeredThings;
+	std::vector<std::unique_ptr<registeredAnything>> registeredRegexesAndMatchers;
 };
 
 } // namespace commonItems

--- a/Parser.h
+++ b/Parser.h
@@ -27,67 +27,51 @@ class registeredAnything
 	virtual bool match(const std::string& lexeme, std::istream& theStream) = 0;
 	virtual bool matchStripped(const std::string& lexeme, const std::string& strippedLexeme, std::istream& theStream) = 0;
 };
+
 class registeredRegex: public registeredAnything
 {
   private:
 	std::regex regex;
 	parsingFunction function;
   public:
-	registeredRegex(const std::string& keyword, const parsingFunction& function):
-		 regex(std::regex(keyword)), function{function}
-	{
-	}
-	bool match(const std::string& lexeme, std::istream& theStream)
-	{
-		if (!std::regex_match(lexeme, regex))
-			return false;
-		else
-		{
-			function(lexeme, theStream);
-			return true;
-		}
-	}
-	bool matchStripped(const std::string& lexeme, const std::string& strippedLexeme, std::istream& theStream) {
-		if (!std::regex_match(strippedLexeme, regex))
-			return false;
-		else
-		{
-			function(lexeme, theStream);
-			return true;
-		}
-	}
+	registeredRegex(const std::string& keyword, const parsingFunction& function);
+	bool match(const std::string& lexeme, std::istream& theStream);
+	bool matchStripped(const std::string& lexeme, const std::string& strippedLexeme, std::istream& theStream);
 };
+
+class registeredRegexStreamOnly: public registeredAnything
+{
+  private:
+	std::regex regex;
+	parsingFunctionStreamOnly function;
+  public:
+	registeredRegexStreamOnly(const std::string& keyword, const parsingFunctionStreamOnly& function);
+	bool match(const std::string& lexeme, std::istream& theStream);
+	bool matchStripped(const std::string& lexeme, const std::string& strippedLexeme, std::istream& theStream);
+};
+
 class registeredMatcher: public registeredAnything
 {
   private:
 	bool (*matcher)(std::string_view);
 	parsingFunction function;
   public:
-	registeredMatcher(bool (*matcher)(std::string_view), const parsingFunction& function):
-		 matcher(matcher), function{function}
-	{
-	}
-	bool match(const std::string& lexeme, std::istream& theStream)
-	{
-		if (!matcher(lexeme))
-			return false;
-		else
-		{
-			function(lexeme, theStream);
-			return true;
-		}
-	}
-	bool matchStripped(const std::string& lexeme, const std::string& strippedLexeme, std::istream& theStream)
-	{
-		if (!matcher(strippedLexeme))
-			return false;
-		else
-		{
-			function(lexeme, theStream);
-			return true;
-		}
-	}
+	registeredMatcher(bool (*matcher)(std::string_view), const parsingFunction& function);
+	bool match(const std::string& lexeme, std::istream& theStream);
+	bool matchStripped(const std::string& lexeme, const std::string& strippedLexeme, std::istream& theStream);
 };
+
+class registeredMatcherStreamOnly: public registeredAnything
+{
+  private:
+	bool (*matcher)(std::string_view);
+	parsingFunctionStreamOnly function;
+  public:
+	registeredMatcherStreamOnly(bool (*matcher)(std::string_view), const parsingFunctionStreamOnly& function);
+	bool match(const std::string& lexeme, std::istream& theStream);
+	bool matchStripped(const std::string& lexeme, const std::string& strippedLexeme, std::istream& theStream);
+};
+
 
 
 class parser
@@ -103,7 +87,9 @@ class parser
 	void registerKeyword(const std::string& keyword, const parsingFunctionStreamOnly& function);
 	void registerKeyword(const std::string& keyword, const parsingFunction& function); // for the few keywords that need to be returned
 	// for compile time regex matchers, but will work with any function that has the same return and argument type
+	void registerMatcher(bool (*matcher)(std::string_view), const parsingFunctionStreamOnly& function);
 	void registerMatcher(bool (*matcher)(std::string_view), const parsingFunction& function);
+	void registerRegex(const std::string& keyword, const parsingFunctionStreamOnly& function);
 	void registerRegex(const std::string& keyword, const parsingFunction& function);
 	
 	void clearRegisteredKeywords() noexcept;

--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -13,7 +13,7 @@ namespace commonItems
 std::string getNextLexeme(std::istream& theStream);
 
 
-void ignoreItem(const std::string& unused, std::istream& theStream)
+void ignoreItem(std::istream& theStream)
 {
 	auto next = getNextLexeme(theStream);
 	if (next == "=")
@@ -59,7 +59,7 @@ void ignoreItem(const std::string& unused, std::istream& theStream)
 }
 
 
-void ignoreObject(const std::string& unused, std::istream& theStream)
+void ignoreObject(std::istream& theStream)
 {
 	auto braceDepth = 0;
 	while (true)
@@ -86,7 +86,7 @@ void ignoreObject(const std::string& unused, std::istream& theStream)
 }
 
 
-void ignoreString(const std::string& unused, std::istream& theStream)
+void ignoreString(std::istream& theStream)
 {
 	singleString ignore(theStream);
 }
@@ -510,7 +510,7 @@ stringsOfItems::stringsOfItems(std::istream& theStream)
 stringsOfItemNames::stringsOfItemNames(std::istream& theStream)
 {
 	registerMatcher(catchallRegexMatch, [this](const std::string& itemName, std::istream& theStream) {
-		ignoreItem(itemName, theStream);
+		ignoreItem(theStream);
 		theStrings.push_back(itemName);
 	});
 

--- a/ParserHelpers.h
+++ b/ParserHelpers.h
@@ -11,9 +11,9 @@
 namespace commonItems
 {
 
-void ignoreItem(const std::string& unused, std::istream& theStream);
-void ignoreObject(const std::string& unused, std::istream& theStream);
-void ignoreString(const std::string& unused, std::istream& theStream);
+void ignoreItem(std::istream& theStream);
+void ignoreObject(std::istream& theStream);
+void ignoreString(std::istream& theStream);
 
 template <typename T>
 [[nodiscard]] std::enable_if_t<std::is_integral_v<T>, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning = false);

--- a/tests/CommonItemsTests.vcxproj.filters
+++ b/tests/CommonItemsTests.vcxproj.filters
@@ -142,10 +142,8 @@
     <CopyFileToFolders Include="TestFiles\version.txt">
       <Filter>TestFiles</Filter>
     </CopyFileToFolders>
-  </ItemGroup>
-  <ItemGroup>
-    <Text Include="TestFiles\emptyVersion.txt">
+    <CopyFileToFolders Include="TestFiles\emptyVersion.txt">
       <Filter>TestFiles</Filter>
-    </Text>
+    </CopyFileToFolders>
   </ItemGroup>
 </Project>

--- a/tests/ParserHelperTests.cpp
+++ b/tests/ParserHelperTests.cpp
@@ -8,7 +8,7 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresSimpleText)
 {
 	std::stringstream input{"ignore_me More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -20,7 +20,7 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresAssignedText)
 {
 	std::stringstream input{"= ignore_me More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -32,7 +32,7 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresBracedItem)
 {
 	std::stringstream input{"{ { ignore_me } } More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -44,7 +44,7 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresAssignedBracedItem)
 {
 	std::stringstream input{"= { { ignore_me } } More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -56,7 +56,7 @@ TEST(ParserHelper_Tests, IgnoreObjectIgnoresNextItem)
 {
 	std::stringstream input{"ignore_me More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -68,7 +68,7 @@ TEST(ParserHelper_Tests, IgnoreObjectIgnoresWholeBracedItem)
 {
 	std::stringstream input{"{ { ignore_me } } More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -80,7 +80,7 @@ TEST(ParserHelper_Tests, IgnoreStringIgnoresNextItem)
 {
 	std::stringstream input{"ignore_me More text"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -92,7 +92,7 @@ TEST(ParserHelper_Tests, IgnoreStringIgnoresWholeQuoation)
 {
 	std::stringstream input{R"("ignore_me More" text)"};
 	input >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
+	commonItems::ignoreItem(input);
 
 	char buffer[256];
 	input.getline(buffer, sizeof buffer);
@@ -898,8 +898,8 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresSimpleColorWithColorSpace)
 	std::stringstream input2{"hsv {0.1 1.0 0.6} More text"};
 	input >> std::noskipws;
 	input2 >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
-	commonItems::ignoreItem("unused", input2);
+	commonItems::ignoreItem(input);
+	commonItems::ignoreItem(input2);
 
 	char buffer[256];
 	char buffer2[256];
@@ -916,8 +916,8 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresAssignedColorWithColorSpace)
 	std::stringstream input2{"= hsv {0.1 1.0 0.6} More text"};
 	input >> std::noskipws;
 	input2 >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
-	commonItems::ignoreItem("unused", input2);
+	commonItems::ignoreItem(input);
+	commonItems::ignoreItem(input2);
 
 	char buffer[256];
 	char buffer2[256];
@@ -934,8 +934,8 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresRgbAndHsvStringsWithoutBreakingParsing
 	std::stringstream input2{"= hsv next_parameter = 420 More text"};
 	input >> std::noskipws;
 	input2 >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
-	commonItems::ignoreItem("unused", input2);
+	commonItems::ignoreItem(input);
+	commonItems::ignoreItem(input2);
 
 	char buffer[256];
 	char buffer2[256];
@@ -952,8 +952,8 @@ TEST(ParserHelper_Tests, IgnoreItemIgnoresQuotedRgbAndHsvStringsWithoutBreakingP
 	std::stringstream input2{"= \"hsv\" next_parameter = 420 More text"};
 	input >> std::noskipws;
 	input2 >> std::noskipws;
-	commonItems::ignoreItem("unused", input);
-	commonItems::ignoreItem("unused", input2);
+	commonItems::ignoreItem(input);
+	commonItems::ignoreItem(input2);
 
 	char buffer[256];
 	char buffer2[256];


### PR DESCRIPTION
- Removed unneeded escaping backslashes in regexes
- **Fixed parsing being broken by registerRegex and registerMatcher using separate vectors. They now use one `registeredRegexesAndMatchers` vector**
- **StreamOnly versions of registerRegex and registerMatcher**
- Purge of "unused" in ParserHelpers