### PR TITLE
stringToDouble and stringToInteger

### DIFF
--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -105,6 +105,16 @@ std::enable_if_t<std::is_integral_v<T>, T> stringToInteger(const std::string& st
 	}
 	return theInteger;
 }
+template char stringToInteger<char>(const std::string& str, bool skipPartialMatchWarning);
+template unsigned char stringToInteger<unsigned char>(const std::string& str, bool skipPartialMatchWarning);
+template short stringToInteger<short>(const std::string& str, bool skipPartialMatchWarning);
+template unsigned short stringToInteger<unsigned short>(const std::string& str, bool skipPartialMatchWarning);
+template int stringToInteger<int>(const std::string& str, bool skipPartialMatchWarning);
+template unsigned int stringToInteger<unsigned int>(const std::string& str, bool skipPartialMatchWarning);
+template long stringToInteger<long>(const std::string& str, bool skipPartialMatchWarning);
+template unsigned long stringToInteger<unsigned long>(const std::string& str, bool skipPartialMatchWarning);
+template long long stringToInteger<long long>(const std::string& str, bool skipPartialMatchWarning);
+template unsigned long long stringToInteger<unsigned long long>(const std::string& str, bool skipPartialMatchWarning);
 
 double stringToDouble(const std::string& str)
 {

--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -2,8 +2,8 @@
 #include "CommonRegexes.h"
 #include "Log.h"
 #include "StringUtils.h"
-#include <locale>
 #include <sstream>
+#include <charconv>
 
 
 
@@ -92,6 +92,33 @@ void ignoreString(const std::string& unused, std::istream& theStream)
 }
 
 
+
+template <typename T>
+std::enable_if_t<std::is_integral_v<T>, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning) // for integral types only
+{
+	T theInteger{0};
+	const auto last = str.data() + str.size();
+	const auto [ptr, ec] = std::from_chars(str.data(), last, theInteger);
+	if (ec != std::errc() || (!skipPartialMatchWarning && ptr != last)) // conversion either failed or was successful but not all characters matched
+	{
+		Log(LogLevel::Warning) << "string to integer: invalid argument! " << str;
+	}
+	return theInteger;
+}
+
+double stringToDouble(const std::string& str)
+{
+	double theDouble{0.0};
+	const auto last = str.data() + str.size();
+	const auto [ptr, ec] = std::from_chars(str.data(), last, theDouble);
+	if (ec != std::errc() || ptr != last) // conversion either failed or was successful but not all characters matched
+	{
+		Log(LogLevel::Warning) << "string to double: invalid argument! " << str;
+	}
+	return theDouble;
+}
+
+
 [[nodiscard]] std::vector<int> getInts(std::istream& theStream)
 {
 	return intList{theStream}.getInts();
@@ -155,11 +182,11 @@ void ignoreString(const std::string& unused, std::istream& theStream)
 intList::intList(std::istream& theStream)
 {
 	registerRegex(integerRegex, [this](const std::string& theInt, std::istream& unused) {
-		integers.push_back(std::stoi(theInt));
+		integers.push_back(stringToInteger<int>(theInt));
 	});
 	registerRegex(quotedIntegerRegex, [this](const std::string& theInt, std::istream& unused) {
 		const auto newInt = theInt.substr(1, theInt.size() - 2);
-		integers.push_back(std::stoi(newInt));
+		integers.push_back(stringToInteger<int>(newInt));
 	});
 
 	parseStream(theStream);
@@ -169,11 +196,11 @@ intList::intList(std::istream& theStream)
 llongList::llongList(std::istream& theStream)
 {
 	registerRegex(integerRegex, [this](const std::string& theLongLong, std::istream& unused) {
-		llongs.push_back(std::stoll(theLongLong));
+		llongs.push_back(stringToInteger<long long>(theLongLong));
 	});
 	registerRegex(quotedIntegerRegex, [this](const std::string& theLongLong, std::istream& unused) {
 		const auto newLlong = theLongLong.substr(1, theLongLong.size() - 2);
-		llongs.push_back(std::stoll(newLlong));
+		llongs.push_back(stringToInteger<long long>(newLlong));
 	});
 
 	parseStream(theStream);
@@ -183,11 +210,11 @@ llongList::llongList(std::istream& theStream)
 ullongList::ullongList(std::istream& theStream)
 {
 	registerRegex(integerRegex, [this](const std::string& theUnsignedLongLong, std::istream& unused) {
-		ullongs.push_back(std::stoull(theUnsignedLongLong));
+		ullongs.push_back(stringToInteger<unsigned long long>(theUnsignedLongLong));
 	});
 	registerRegex(quotedIntegerRegex, [this](const std::string& theUnsignedLongLong, std::istream& unused) {
 		const auto newULlong = theUnsignedLongLong.substr(1, theUnsignedLongLong.size() - 2);
-		ullongs.push_back(std::stoull(newULlong));
+		ullongs.push_back(stringToInteger<unsigned long long>(newULlong));
 	});
 
 	parseStream(theStream);
@@ -199,15 +226,7 @@ singleInt::singleInt(std::istream& theStream)
 	getNextTokenWithoutMatching(theStream); // remove equals
 	const auto token = remQuotes(*getNextTokenWithoutMatching(theStream));
 
-	try
-	{
-		theInt = stoi(token);
-	}
-	catch (std::exception&)
-	{
-		Log(LogLevel::Warning) << "Expected an int, but instead got " << token;
-		theInt = 0;
-	}
+	theInt = stringToInteger<int>(token);
 }
 
 
@@ -216,15 +235,7 @@ singleLlong::singleLlong(std::istream& theStream)
 	getNextTokenWithoutMatching(theStream); // remove equals
 	const auto token = remQuotes(*getNextTokenWithoutMatching(theStream));
 
-	try
-	{
-		theLongLong = std::stoll(token);
-	}
-	catch (std::exception&)
-	{
-		Log(LogLevel::Warning) << "Expected a long long, but instead got " << token;
-		theLongLong = 0;
-	}
+	theLongLong = stringToInteger<long long>(token);
 }
 
 
@@ -233,15 +244,7 @@ singleULlong::singleULlong(std::istream& theStream)
 	getNextTokenWithoutMatching(theStream); // equals
 	const auto token = remQuotes(*getNextTokenWithoutMatching(theStream));
 
-	try
-	{
-		theUnsignedLongLong = std::stoull(token);
-	}
-	catch (std::exception&)
-	{
-		Log(LogLevel::Warning) << "Expected an unsigned long long, but instead got " << token;
-		theUnsignedLongLong = 0;
-	}
+	theUnsignedLongLong = stringToInteger<unsigned long long>(token);
 }
 
 
@@ -308,18 +311,18 @@ int simpleObject::getValueAsInt(const std::string& key) const
 	{
 		return 0;
 	}
-	return std::stoi(value);
+	return stringToInteger<int>(value);
 }
 
 
 doubleList::doubleList(std::istream& theStream)
 {
 	registerRegex(floatRegex, [this](const std::string& theDouble, std::istream& unused) {
-		doubles.push_back(std::stod(theDouble));
+		doubles.push_back(stringToDouble(theDouble));
 	});
 	registerRegex(quotedFloatRegex, [this](const std::string& theDouble, std::istream& unused) {
 		const auto newDouble = remQuotes(theDouble);
-		doubles.push_back(std::stod(newDouble));
+		doubles.push_back(stringToDouble(newDouble));
 	});
 
 	parseStream(theStream);
@@ -331,15 +334,7 @@ singleDouble::singleDouble(std::istream& theStream)
 	getNextTokenWithoutMatching(theStream); // remove equals
 	const auto token = remQuotes(*getNextTokenWithoutMatching(theStream));
 
-	try
-	{
-		theDouble = stod(token);
-	}
-	catch (std::exception&)
-	{
-		Log(LogLevel::Warning) << "Expected a double, but instead got " << token;
-		theDouble = 0.0;
-	}
+	theDouble = stringToDouble(token);
 }
 
 

--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -101,7 +101,7 @@ std::enable_if_t<std::is_integral_v<T>, T> stringToInteger(const std::string& st
 	const auto [ptr, ec] = std::from_chars(str.data(), last, theInteger);
 	if (ec != std::errc() || (!skipPartialMatchWarning && ptr != last)) // conversion either failed or was successful but not all characters matched
 	{
-		Log(LogLevel::Warning) << "string to integer: invalid argument! " << str;
+		Log(LogLevel::Warning) << "string to integer - invalid argument: " << str;
 	}
 	return theInteger;
 }

--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -94,7 +94,7 @@ void ignoreString(const std::string& unused, std::istream& theStream)
 
 
 template <typename T>
-std::enable_if_t<std::numeric_limits<T>::is_integer, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning) // for integral types only
+std::enable_if_t<std::numeric_limits<T>::is_integer, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning) // for integer types only
 {
 	T theInteger = 0;
 	const auto last = str.data() + str.size();

--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -94,9 +94,9 @@ void ignoreString(const std::string& unused, std::istream& theStream)
 
 
 template <typename T>
-std::enable_if_t<std::is_integral_v<T>, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning) // for integral types only
+std::enable_if_t<std::numeric_limits<T>::is_integer, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning) // for integral types only
 {
-	T theInteger{0};
+	T theInteger = 0;
 	const auto last = str.data() + str.size();
 	const auto [ptr, ec] = std::from_chars(str.data(), last, theInteger);
 	if (ec != std::errc() || (!skipPartialMatchWarning && ptr != last)) // conversion either failed or was successful but not all characters matched
@@ -118,7 +118,7 @@ template unsigned long long stringToInteger<unsigned long long>(const std::strin
 
 double stringToDouble(const std::string& str)
 {
-	double theDouble{0.0};
+	double theDouble = 0.0;
 	const auto last = str.data() + str.size();
 	const auto [ptr, ec] = std::from_chars(str.data(), last, theDouble);
 	if (ec != std::errc() || ptr != last) // conversion either failed or was successful but not all characters matched

--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -105,7 +105,7 @@ std::enable_if_t<std::numeric_limits<T>::is_integer, T> stringToInteger(const st
 	}
 	return theInteger;
 }
-template char stringToInteger<char>(const std::string& str, bool skipPartialMatchWarning);
+template signed char stringToInteger<signed char>(const std::string& str, bool skipPartialMatchWarning);
 template unsigned char stringToInteger<unsigned char>(const std::string& str, bool skipPartialMatchWarning);
 template short stringToInteger<short>(const std::string& str, bool skipPartialMatchWarning);
 template unsigned short stringToInteger<unsigned short>(const std::string& str, bool skipPartialMatchWarning);

--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -123,7 +123,7 @@ double stringToDouble(const std::string& str)
 	const auto [ptr, ec] = std::from_chars(str.data(), last, theDouble);
 	if (ec != std::errc() || ptr != last) // conversion either failed or was successful but not all characters matched
 	{
-		Log(LogLevel::Warning) << "string to double: invalid argument! " << str;
+		Log(LogLevel::Warning) << "string to double - invalid argument: " << str;
 	}
 	return theDouble;
 }

--- a/ParserHelpers.h
+++ b/ParserHelpers.h
@@ -5,6 +5,7 @@
 
 #include "Parser.h"
 #include <map>
+#include <type_traits>
 
 
 namespace commonItems
@@ -13,6 +14,10 @@ namespace commonItems
 void ignoreItem(const std::string& unused, std::istream& theStream);
 void ignoreObject(const std::string& unused, std::istream& theStream);
 void ignoreString(const std::string& unused, std::istream& theStream);
+
+template <typename T>
+[[nodiscard]] std::enable_if_t<std::is_integral_v<T>, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning = false);
+[[nodiscard]] double stringToDouble(const std::string& str);
 
 [[nodiscard]] std::vector<int> getInts(std::istream& theStream);
 [[nodiscard]] std::vector<long long> getLlongs(std::istream& theStream);

--- a/ParserHelpers.h
+++ b/ParserHelpers.h
@@ -17,9 +17,19 @@ void ignoreString(const std::string& unused, std::istream& theStream);
 
 
 /*function template only enabled for integer types
-* converts string to integer types, e.g. unsigned int value = stringToInteger<unsigned int>("420");
-* works for signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long
-*/
+* converts string to integer types, e.g.: unsigned int value = stringToInteger<unsigned int>("420");
+* works for:
+* signed char stringToInteger<signed char>(const std::string& str, bool skipPartialMatchWarning);
+* unsigned char stringToInteger<unsigned char>(const std::string& str, bool skipPartialMatchWarning);
+* short stringToInteger<short>(const std::string& str, bool skipPartialMatchWarning);
+* unsigned short stringToInteger<unsigned short>(const std::string& str, bool skipPartialMatchWarning);
+* int stringToInteger<int>(const std::string& str, bool skipPartialMatchWarning);
+* unsigned int stringToInteger<unsigned int>(const std::string& str, bool skipPartialMatchWarning);
+* long stringToInteger<long>(const std::string& str, bool skipPartialMatchWarning);
+* unsigned long stringToInteger<unsigned long>(const std::string& str, bool skipPartialMatchWarning);
+* long long stringToInteger<long long>(const std::string& str, bool skipPartialMatchWarning);
+ * unsigned long long stringToInteger<unsigned long long>(const std::string& str, bool skipPartialMatchWarning);
+ */
 template <typename T>
 [[nodiscard]] std::enable_if_t<std::numeric_limits<T>::is_integer, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning = false);
 

--- a/ParserHelpers.h
+++ b/ParserHelpers.h
@@ -15,11 +15,16 @@ void ignoreItem(const std::string& unused, std::istream& theStream);
 void ignoreObject(const std::string& unused, std::istream& theStream);
 void ignoreString(const std::string& unused, std::istream& theStream);
 
+
+/*function template only enabled for integer types
+* converts string to integer types, e.g. unsigned int value = stringToInteger<unsigned int>("420");
+* works for signed char, unsigned char, short, unsigned short, int, unsigned int, long, unsigned long, long long, unsigned long long
+*/
 template <typename T>
-// function template only enabled for integer types
 [[nodiscard]] std::enable_if_t<std::numeric_limits<T>::is_integer, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning = false);
 
 [[nodiscard]] double stringToDouble(const std::string& str);
+
 
 [[nodiscard]] std::vector<int> getInts(std::istream& theStream);
 [[nodiscard]] std::vector<long long> getLlongs(std::istream& theStream);

--- a/ParserHelpers.h
+++ b/ParserHelpers.h
@@ -28,8 +28,8 @@ void ignoreString(const std::string& unused, std::istream& theStream);
 * long stringToInteger<long>(const std::string& str, bool skipPartialMatchWarning);
 * unsigned long stringToInteger<unsigned long>(const std::string& str, bool skipPartialMatchWarning);
 * long long stringToInteger<long long>(const std::string& str, bool skipPartialMatchWarning);
- * unsigned long long stringToInteger<unsigned long long>(const std::string& str, bool skipPartialMatchWarning);
- */
+* unsigned long long stringToInteger<unsigned long long>(const std::string& str, bool skipPartialMatchWarning);
+*/
 template <typename T>
 [[nodiscard]] std::enable_if_t<std::numeric_limits<T>::is_integer, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning = false);
 

--- a/ParserHelpers.h
+++ b/ParserHelpers.h
@@ -16,7 +16,9 @@ void ignoreObject(const std::string& unused, std::istream& theStream);
 void ignoreString(const std::string& unused, std::istream& theStream);
 
 template <typename T>
-[[nodiscard]] std::enable_if_t<std::is_integral_v<T>, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning = false);
+// function template only enabled for integer types
+[[nodiscard]] std::enable_if_t<std::numeric_limits<T>::is_integer, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning = false);
+
 [[nodiscard]] double stringToDouble(const std::string& str);
 
 [[nodiscard]] std::vector<int> getInts(std::istream& theStream);

--- a/tests/ParserHelperTests.cpp
+++ b/tests/ParserHelperTests.cpp
@@ -112,7 +112,7 @@ TEST(ParserHelper_Tests, stringToIntegerLogsNotFullyMatchingInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to integer: invalid argument! 345 foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to integer - invalid argument: 345 foo\n", log.str());
 	ASSERT_EQ(345, theInteger);
 }
 
@@ -128,7 +128,7 @@ TEST(ParserHelper_Tests, stringToIntegerLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to integer: invalid argument! foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to integer - invalid argument: foo\n", log.str());
 	ASSERT_EQ(0, theInteger);
 }
 TEST(ParserHelper_Tests, stringToDoubleLogsNotFullyMatchingInput)
@@ -143,7 +143,7 @@ TEST(ParserHelper_Tests, stringToDoubleLogsNotFullyMatchingInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to double: invalid argument! 345.69 foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to double - invalid argument: 345.69 foo\n", log.str());
 	ASSERT_EQ(345.69, theDouble);
 }
 
@@ -159,7 +159,7 @@ TEST(ParserHelper_Tests, stringToDoubleLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to double: invalid argument! foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to double - invalid argument: foo\n", log.str());
 	ASSERT_EQ(0, theDouble);
 }
 
@@ -387,7 +387,7 @@ TEST(ParserHelper_Tests, SingleIntLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to integer: invalid argument! foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to integer - invalid argument: foo\n", log.str());
 	ASSERT_EQ(0, theInteger.getInt());
 }
 
@@ -459,7 +459,7 @@ TEST(ParserHelper_Tests, SingleLlongLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to integer: invalid argument! foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to integer - invalid argument: foo\n", log.str());
 	ASSERT_EQ(0, theLlong.getLlong());
 }
 
@@ -475,7 +475,7 @@ TEST(ParserHelper_Tests, SingleULlongLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to integer: invalid argument! foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to integer - invalid argument: foo\n", log.str());
 	ASSERT_EQ(0, theULlong.getULlong());
 }
 
@@ -630,7 +630,7 @@ TEST(ParserHelper_Tests, SingleDoubleLogsNotFullyMatchingInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to double: invalid argument! 345.345 foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to double - invalid argument: 345.345 foo\n", log.str());
 	ASSERT_EQ(345.345, theDouble.getDouble());
 }
 
@@ -646,7 +646,7 @@ TEST(ParserHelper_Tests, SingleDoubleLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to double: invalid argument! foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to double - invalid argument: foo\n", log.str());
 	ASSERT_EQ(0, theDouble.getDouble());
 }
 

--- a/tests/ParserHelperTests.cpp
+++ b/tests/ParserHelperTests.cpp
@@ -99,6 +99,78 @@ TEST(ParserHelper_Tests, IgnoreStringIgnoresWholeQuoation)
 	ASSERT_EQ(" text", std::string{buffer});
 }
 
+
+TEST(ParserHelper_Tests, stringToIntegerLogsNotFullyMatchingInput)
+{
+	std::string str{R"(345 foo)"};
+
+	const std::stringstream log;
+	auto* const stdOutBuf = std::cout.rdbuf();
+	std::cout.rdbuf(log.rdbuf());
+
+	const auto theInteger = commonItems::stringToInteger<int>(str);
+
+	std::cout.rdbuf(stdOutBuf);
+
+	ASSERT_EQ(" [WARNING] string to integer: invalid argument! 345 foo\n", log.str());
+	ASSERT_EQ(345, theInteger);
+}
+
+TEST(ParserHelper_Tests, stringToIntegerLogsInvalidInput)
+{
+	std::string str{R"(foo)"};
+
+	const std::stringstream log;
+	auto* const stdOutBuf = std::cout.rdbuf();
+	std::cout.rdbuf(log.rdbuf());
+
+	const auto theInteger = commonItems::stringToInteger<int>(str);
+
+	std::cout.rdbuf(stdOutBuf);
+
+	ASSERT_EQ(" [WARNING] string to integer: invalid argument! foo\n", log.str());
+	ASSERT_EQ(0, theInteger);
+}
+TEST(ParserHelper_Tests, stringToDoubleLogsNotFullyMatchingInput)
+{
+	std::string str{R"(345.69 foo)"};
+
+	const std::stringstream log;
+	auto* const stdOutBuf = std::cout.rdbuf();
+	std::cout.rdbuf(log.rdbuf());
+
+	const double theDouble = commonItems::stringToDouble(str);
+
+	std::cout.rdbuf(stdOutBuf);
+
+	ASSERT_EQ(" [WARNING] string to double: invalid argument! 345.69 foo\n", log.str());
+	ASSERT_EQ(345.69, theDouble);
+}
+
+TEST(ParserHelper_Tests, stringToDoubleLogsInvalidInput)
+{
+	std::string str{R"(foo)"};
+
+	const std::stringstream log;
+	auto* const stdOutBuf = std::cout.rdbuf();
+	std::cout.rdbuf(log.rdbuf());
+
+	const double theDouble = commonItems::stringToDouble(str);
+
+	std::cout.rdbuf(stdOutBuf);
+
+	ASSERT_EQ(" [WARNING] string to double: invalid argument! foo\n", log.str());
+	ASSERT_EQ(0, theDouble);
+}
+
+TEST(ParserHelper_Tests, stringToDoubleWorksSucceedsWithValidInput)
+{
+	std::string str{R"(345.69)"};
+
+	const double theDouble = commonItems::stringToDouble(str);
+	ASSERT_EQ(345.69, theDouble);
+}
+
 TEST(ParserHelper_Tests, IntListDefaultsToEmpty)
 {
 	std::stringstream input;
@@ -315,7 +387,7 @@ TEST(ParserHelper_Tests, SingleIntLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] Expected an int, but instead got foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to integer: invalid argument! foo\n", log.str());
 	ASSERT_EQ(0, theInteger.getInt());
 }
 
@@ -387,7 +459,7 @@ TEST(ParserHelper_Tests, SingleLlongLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] Expected a long long, but instead got foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to integer: invalid argument! foo\n", log.str());
 	ASSERT_EQ(0, theLlong.getLlong());
 }
 
@@ -403,7 +475,7 @@ TEST(ParserHelper_Tests, SingleULlongLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] Expected an unsigned long long, but instead got foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to integer: invalid argument! foo\n", log.str());
 	ASSERT_EQ(0, theULlong.getULlong());
 }
 
@@ -546,6 +618,21 @@ TEST(ParserHelper_Tests, SingleDoubleGetsQuotedDoubleAfterEquals)
 	ASSERT_EQ(1.25, theDouble.getDouble());
 }
 
+TEST(ParserHelper_Tests, SingleDoubleLogsNotFullyMatchingInput)
+{
+	std::stringstream input{R"(= "345.345 foo")"};
+
+	const std::stringstream log;
+	auto* const stdOutBuf = std::cout.rdbuf();
+	std::cout.rdbuf(log.rdbuf());
+
+	const commonItems::singleDouble theDouble(input);
+
+	std::cout.rdbuf(stdOutBuf);
+
+	ASSERT_EQ(" [WARNING] string to double: invalid argument! 345.345 foo\n", log.str());
+	ASSERT_EQ(345.345, theDouble.getDouble());
+}
 
 TEST(ParserHelper_Tests, SingleDoubleLogsInvalidInput)
 {
@@ -559,7 +646,7 @@ TEST(ParserHelper_Tests, SingleDoubleLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] Expected a double, but instead got foo\n", log.str());
+	ASSERT_EQ(" [WARNING] string to double: invalid argument! foo\n", log.str());
 	ASSERT_EQ(0, theDouble.getDouble());
 }
 


### PR DESCRIPTION
- finally a clean way to convert string to unsigned int, instead of this monstrosity:
```
		const auto result = std::stoul(valStr);
		if (result > std::numeric_limits<unsigned>::max()) {
			throw std::out_of_range("stou out of range for " + valStr);
		}
```
- speed (at least with MSVC)



With GCC 11.1 we should be able to compile this on Linux.

