### PR TITLE
Fix Linux build

### DIFF
--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -94,7 +94,7 @@ void ignoreString(const std::string& unused, std::istream& theStream)
 
 
 template <typename T>
-std::enable_if_t<std::numeric_limits<T>::is_integer, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning) // for integer types only
+std::enable_if_t<std::is_integral_v<T>, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning) // for integral types only
 {
 	T theInteger = 0;
 	const auto last = str.data() + str.size();

--- a/ParserHelpers.h
+++ b/ParserHelpers.h
@@ -31,7 +31,7 @@ void ignoreString(const std::string& unused, std::istream& theStream);
 * unsigned long long stringToInteger<unsigned long long>(const std::string& str, bool skipPartialMatchWarning);
 */
 template <typename T>
-[[nodiscard]] std::enable_if_t<std::numeric_limits<T>::is_integer, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning = false);
+[[nodiscard]] std::enable_if_t<std::is_integral_v<T>, T> stringToInteger(const std::string& str, bool skipPartialMatchWarning = false);
 
 [[nodiscard]] double stringToDouble(const std::string& str);
 


### PR DESCRIPTION
```std::enable_if_t<std::numeric_limits<T>::is_integer, T>``` doesn't seem to work with unsigned long long and GCC for some reason.
I'm changing back to ```std::enable_if_t<std::is_integral_v<T>, T>```, which works.