### PR TITLE
ignoreAndLogItem function

### DIFF
--- a/ParserHelpers.cpp
+++ b/ParserHelpers.cpp
@@ -58,6 +58,12 @@ void ignoreItem(const std::string& unused, std::istream& theStream)
 	}
 }
 
+void ignoreAndLogItem(const std::string& keyword, std::istream& theStream)
+{
+	Log(LogLevel::Debug) << "Ignoring keyword: " << keyword;
+	ignoreItem(keyword, theStream);
+}
+
 
 void ignoreObject(const std::string& unused, std::istream& theStream)
 {

--- a/ParserHelpers.h
+++ b/ParserHelpers.h
@@ -13,6 +13,7 @@ namespace commonItems
 {
 
 void ignoreItem(const std::string& unused, std::istream& theStream);
+void ignoreAndLogItem(const std::string& keyword, std::istream& theStream);
 void ignoreObject(const std::string& unused, std::istream& theStream);
 void ignoreString(const std::string& unused, std::istream& theStream);
 


### PR DESCRIPTION
Useful for discovering not covered keywords without breaking the parsing.