### PR TITLE
Fix for old-style mod loading.

### DIFF
--- a/ModLoader/ModLoader.h
+++ b/ModLoader/ModLoader.h
@@ -1,5 +1,6 @@
 #ifndef MOD_LOADER_H
 #define MOD_LOADER_H
+#include <map>
 #include <optional>
 #include <set>
 #include <string>
@@ -33,6 +34,7 @@ class ModLoader
 
   private:
 	void loadModDirectory(const std::string& gameDocumentsPath, const Mods& incomingMods);
+	void cacheModNames(const std::string& gameDocumentsPath);
 	void processLoadedMod(ModParser& theMod,
 		 const std::string& modName,
 		 const std::string& modFileName,
@@ -48,6 +50,8 @@ class ModLoader
 	Mods possibleUncompressedMods = {}; // name, absolute path to mod directory
 	Mods possibleCompressedMods = {};	// name, absolute path to zip file
 	Mods usableMods = {};					// name, absolute path for directories, relative for unpacked
+
+	std::map<Name, Path> modCache;
 };
 } // namespace commonItems
 

--- a/tests/ModLoaderTests.cpp
+++ b/tests/ModLoaderTests.cpp
@@ -4,7 +4,7 @@
 #include <gmock/gmock-matchers.h>
 using testing::UnorderedElementsAre;
 
-TEST(ModLoaderTests, ModsCanBeLocatedUnpackedAndUpdated)
+TEST(ModLoaderTests, ModsByPathCanBeLocatedUnpackedAndUpdated)
 {
 	Mods incomingMods;														  // this is what comes from the save
 	incomingMods.emplace_back(Mod("Some mod", "mod/themod.mod")); // mod's in fact named "The Mod" in the file.

--- a/tests/ModLoaderTests.cpp
+++ b/tests/ModLoaderTests.cpp
@@ -17,6 +17,19 @@ TEST(ModLoaderTests, ModsCanBeLocatedUnpackedAndUpdated)
 	EXPECT_THAT(mods[0].dependencies, UnorderedElementsAre("Packed Mod", "Missing Mod"));
 }
 
+TEST(ModLoaderTests, ModsByNameCanBeLocatedUnpackedAndUpdated)
+{
+	Mods incomingMods;									  // this is what comes from the save
+	incomingMods.emplace_back(Mod("The Mod", "")); // No path given, old-style mod inputs.
+
+	commonItems::ModLoader modLoader;
+	modLoader.loadMods("TestFiles", incomingMods);
+	const auto mods = modLoader.getMods();
+
+	ASSERT_THAT(mods, UnorderedElementsAre(Mod("The Mod", "TestFiles/mod/themod/")));
+	EXPECT_THAT(mods[0].dependencies, UnorderedElementsAre("Packed Mod", "Missing Mod"));
+}
+
 TEST(ModLoaderTests, BrokenMissingAndNonexistentModsAreDiscarded)
 {
 	Mods incomingMods;


### PR DESCRIPTION
Apparently old-style mod name inputs were broken as we expected paths were in the save where in fact names were given.
Now we cache the mod folder for names first, and for old-style lists we update the paths from cached data on the fly.