### PR TITLE
"support" for rgba and hsva

### DIFF
--- a/Color.h
+++ b/Color.h
@@ -6,21 +6,26 @@
 // Represents a Paradox - defined color.
 //
 // Can be directly created in either the RGB or HSV color spaces.
+// If alpha is persent we're assuming it's RGBA or HSVA.
 //
 // Can be imported in :
 // * Unspecified with ints(becomes RGB) - "= { 64 128 128 }"
-// * Unspecified with floats(becomes RGB) - "= { 0.5 0.9 0.1 }"
+// * Unspecified with three floats(becomes RGB) - "= { 0.5 0.9 0.1 }"
+// * Unspecified with four floats(becomes RGBA) - "= { 0.5 0.9 0.1 0.1 }"
 // * RGB - "= rgb { 64 128 128 }"
 // * Hex - "= hex { 408080 }"
 // * HSV - "= hsv { 0.5 0.5 0.5 }"
+// * HSVA - "= hsv { 0.5 0.5 0.5 0.1 }"
 // * HSV360 - "= hsv360 { 180 50 50 }"
 // * Name(requires caching definitions for the named colors in advance) - "= dark_moderate_cyan"
 //
 // Can be output in :
 // * unspecified(rgb) - "= { 64 128 128 }"
 // * RGB - "= rgb { 64 128 128 }"
+// * RGBA - we don't export RGBA. yet.
 // * hex - "= hex { 408080 }"
 // * HSV - "= hsv { 0.5 0.5 0.5 }"
+// * HSVA - "= hsv { 0.5 0.5 0.5 0.1 }"
 // * HSV360 - "= hsv360 { 180 50 50 }"
 //
 // The individual components can be accessed in both RGB and HSV color spaces, equality and inequality can be checked, the color cache can be reviewed and
@@ -43,7 +48,9 @@ class Color
 	class Factory;
 	Color() = default;
 	explicit Color(std::array<int, 3> rgbComponents): rgbComponents(rgbComponents) { deriveHsvFromRgb(); }
+	explicit Color(std::array<int, 3> rgbComponents, float alpha): rgbComponents(rgbComponents), alpha(alpha) { deriveHsvFromRgb(); }
 	explicit Color(std::array<float, 3> hsvComponents): hsvComponents(hsvComponents) { deriveRgbFromHsv(); }
+	explicit Color(std::array<float, 3> hsvComponents, float alpha): hsvComponents(hsvComponents), alpha(alpha) { deriveRgbFromHsv(); }
 
 	bool operator==(const Color& rhs) const;
 	bool operator!=(const Color& rhs) const;
@@ -56,6 +63,7 @@ class Color
 	[[nodiscard]] const auto& h() const { return hsvComponents[0]; }
 	[[nodiscard]] const auto& s() const { return hsvComponents[1]; }
 	[[nodiscard]] const auto& v() const { return hsvComponents[2]; }
+	[[nodiscard]] const auto& a() const { return alpha; }
 
 	[[nodiscard]] std::string outputRgb() const;
 	[[nodiscard]] std::string outputHex() const;
@@ -74,6 +82,7 @@ class Color
 
 	std::array<int, 3> rgbComponents{0, 0, 0};
 	std::array<float, 3> hsvComponents{0.0F, 0.0F, 0.0F};
+	std::optional<float> alpha;
 };
 
 

--- a/tests/ColorTests.cpp
+++ b/tests/ColorTests.cpp
@@ -34,6 +34,22 @@ TEST(Color_Tests, ColorCanBeInitializedWithRgbComponents)
 	ASSERT_NEAR(0.5f, v, 0.01);
 }
 
+TEST(Color_Tests, ColorCanBeInitializedWithRgbaComponents)
+{
+	const commonItems::Color testColor(std::array<int, 3>{64, 128, 128}, 0.5f);
+
+	auto [r, g, b] = testColor.getRgbComponents();
+	EXPECT_EQ(64, r);
+	EXPECT_EQ(128, g);
+	EXPECT_EQ(128, b);
+	EXPECT_EQ(0.5, testColor.a());
+
+	auto [h, s, v] = testColor.getHsvComponents();
+	EXPECT_NEAR(0.5f, h, 0.01);
+	EXPECT_NEAR(0.5f, s, 0.01);
+	EXPECT_NEAR(0.5f, v, 0.01);
+}
+
 
 TEST(Color_Tests, ColorCanBeInitializedWithHsvComponents)
 {
@@ -48,6 +64,22 @@ TEST(Color_Tests, ColorCanBeInitializedWithHsvComponents)
 	ASSERT_NEAR(0.5f, h, 0.01);
 	ASSERT_NEAR(0.5f, s, 0.01);
 	ASSERT_NEAR(0.5f, v, 0.01);
+}
+
+TEST(Color_Tests, ColorCanBeInitializedWithHsvaComponents)
+{
+	const commonItems::Color testColor(std::array<float, 3>{0.5f, 0.5f, 0.5f}, 0.5f);
+
+	auto [r, g, b] = testColor.getRgbComponents();
+	EXPECT_EQ(63, r);
+	EXPECT_EQ(127, g);
+	EXPECT_EQ(127, b);
+	EXPECT_EQ(0.5, testColor.a());
+
+	auto [h, s, v] = testColor.getHsvComponents();
+	EXPECT_NEAR(0.5f, h, 0.01);
+	EXPECT_NEAR(0.5f, s, 0.01);
+	EXPECT_NEAR(0.5f, v, 0.01);
 }
 
 
@@ -330,6 +362,24 @@ TEST(Color_Tests, ColorRGBDoublesCanBeInitializedFromStream) // Yes, this is a t
 	ASSERT_NEAR(0.90f, v, 0.01);
 }
 
+TEST(Color_Tests, ColorRGBADoublesCanBeInitializedFromStream) // Yes, unfortunately this is a thing as well.
+{
+	std::stringstream input;
+	input << "= { 0.5 0.9 0.1 0.5 }";
+	const auto testColor = commonItems::Color::Factory{}.getColor(input);
+
+	auto [r, g, b] = testColor.getRgbComponents();
+	EXPECT_EQ(128, r);
+	EXPECT_EQ(230, g);
+	EXPECT_EQ(26, b);
+	EXPECT_EQ(0.5, testColor.a());
+
+	auto [h, s, v] = testColor.getHsvComponents();
+	EXPECT_NEAR(0.25f, h, 0.01);
+	EXPECT_NEAR(0.89f, s, 0.01);
+	EXPECT_NEAR(0.90f, v, 0.01);
+}
+
 
 TEST(Color_Tests, ColorCanBeInitializedFromStreamWithQuotes)
 {
@@ -427,6 +477,24 @@ TEST(Color_Tests, ColorCanBeInitializedFromStreamInHsv)
 	ASSERT_NEAR(0.5f, h, 0.01);
 	ASSERT_NEAR(0.5f, s, 0.01);
 	ASSERT_NEAR(0.5f, v, 0.01);
+}
+
+TEST(Color_Tests, ColorCanBeInitializedFromStreamInHsva)
+{
+	std::stringstream input;
+	input << "= hsv { 0.5 0.5 0.5 0.5 }";
+	const auto testColor = commonItems::Color::Factory{}.getColor(input);
+
+	auto [r, g, b] = testColor.getRgbComponents();
+	EXPECT_EQ(63, r);
+	EXPECT_EQ(127, g);
+	EXPECT_EQ(127, b);
+	EXPECT_EQ(0.5, testColor.a());
+
+	auto [h, s, v] = testColor.getHsvComponents();
+	EXPECT_NEAR(0.5f, h, 0.01);
+	EXPECT_NEAR(0.5f, s, 0.01);
+	EXPECT_NEAR(0.5f, v, 0.01);
 }
 
 
@@ -719,6 +787,15 @@ TEST(Color_Tests, ColorCanBeOutputInHsvColorSpace)
 	ASSERT_EQ("= hsv { 0.5 0.5 0.5 }", output.str());
 }
 
+TEST(Color_Tests, ColorCanBeOutputInHsvaColorSpace)
+{
+	const commonItems::Color testColor(std::array<int, 3>{64, 128, 128}, 0.5f);
+
+	std::stringstream output;
+	output << testColor.outputHsv();
+
+	EXPECT_EQ("= hsv { 0.5 0.5 0.5 0.5 }", output.str());
+}
 
 TEST(Color_Tests, ColorCanBeOutputInHsv360ColorSpace)
 {


### PR DESCRIPTION
We can now load rgba and hsva, and export hsva. We're mostly ignoring alpha.