### PR TITLE
Log timestamp to console Log output

### DIFF
--- a/Log.cpp
+++ b/Log.cpp
@@ -23,6 +23,7 @@ Log::~Log()
 {
 	logMessageStream << std::endl;
 	const auto logMessage = logMessageStream.str();
+	WriteToConsole(logLevel, logMessage); // write to the console for the sake of tests and Frontend
 	WriteToFile(logLevel, logMessage);
 }
 
@@ -40,10 +41,14 @@ void Log::WriteToFile(LogLevel level, const std::string& logMessage)
 	WriteTheTime(logFile);
 	logFile << logLevelStrings.find(level)->second;
 	logFile << logMessage;
-	std::cout << logLevelStrings.find(level)->second;
-	std::cout << logMessage; // write to the console for the sake of tests
 }
 
+void Log::WriteToConsole(LogLevel level, const std::string& logMessage)
+{
+	WriteTheTime(std::cout);
+	std::cout << logLevelStrings.find(level)->second;
+	std::cout << logMessage;
+}
 
 void Log::WriteTheTime(std::ostream& logFile)
 {

--- a/Log.h
+++ b/Log.h
@@ -59,6 +59,7 @@ class Log
 
   private:
 	static void WriteToFile(LogLevel level, const std::string& logMessage);
+	static void WriteToConsole(LogLevel level, const std::string& logMessage);
 	static void WriteTheTime(std::ostream& logFile);
 
 	LogLevel logLevel;

--- a/tests/DateTests.cpp
+++ b/tests/DateTests.cpp
@@ -125,7 +125,7 @@ TEST(Date_Tests, DateLogsBadInitialization)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(" [WARNING] Problem inputting date:"));
+	EXPECT_THAT(log.str(), testing::HasSubstr("[WARNING] Problem inputting date:"));
 }
 
 

--- a/tests/Localization/LocalizationDatabaseTests.cpp
+++ b/tests/Localization/LocalizationDatabaseTests.cpp
@@ -149,7 +149,7 @@ TEST(Localization_LocalizationDatabase_Tests, LocalizationsFromUnsupportedLangua
 	std::string actual_output = log.str();
 
 	EXPECT_EQ(base_language_lines, 0);
-	EXPECT_EQ(actual_output, " [WARNING] Scraping loc line [ KEY:0 \"value\"] without language specified!\n");
+	EXPECT_THAT(actual_output, testing::HasSubstr(R"( [WARNING] Scraping loc line [ KEY:0 "value"] without language specified!)"));
 
 	EXPECT_EQ(database.size(), 0);
 	EXPECT_FALSE(database.HasLocalization("KEY"));

--- a/tests/Localization/LocalizationDatabaseTests.cpp
+++ b/tests/Localization/LocalizationDatabaseTests.cpp
@@ -149,7 +149,7 @@ TEST(Localization_LocalizationDatabase_Tests, LocalizationsFromUnsupportedLangua
 	std::string actual_output = log.str();
 
 	EXPECT_EQ(base_language_lines, 0);
-	EXPECT_THAT(actual_output, testing::HasSubstr(R"( [WARNING] Scraping loc line [ KEY:0 "value"] without language specified!)"));
+	EXPECT_THAT(actual_output, testing::HasSubstr(R"([WARNING] Scraping loc line [ KEY:0 "value"] without language specified!)"));
 
 	EXPECT_EQ(database.size(), 0);
 	EXPECT_FALSE(database.HasLocalization("KEY"));

--- a/tests/LogTests.cpp
+++ b/tests/LogTests.cpp
@@ -14,7 +14,7 @@ TEST(Log_Tests, ErrorMessagesLogged)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"(   [ERROR] Error message)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([ERROR] Error message)"));
 }
 
 
@@ -28,7 +28,7 @@ TEST(Log_Tests, WarningMessagesLogged)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] Warning message)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([WARNING] Warning message)"));
 }
 
 
@@ -42,7 +42,7 @@ TEST(Log_Tests, InfoMessagesLogged)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"(    [INFO] Info message)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([INFO] Info message)"));
 }
 
 
@@ -56,7 +56,7 @@ TEST(Log_Tests, DebugMessagesLogged)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"(   [DEBUG]     Debug message)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([DEBUG]     Debug message)"));
 }
 
 TEST(Log_Tests, ProgressMessagesLogged)
@@ -82,5 +82,5 @@ TEST(Log_Tests, NoticeMessagesLogged)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"(  [NOTICE] Notice message)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([NOTICE] Notice message)"));
 }

--- a/tests/LogTests.cpp
+++ b/tests/LogTests.cpp
@@ -1,7 +1,7 @@
 #include "../Log.h"
 #include "gtest/gtest.h"
+#include <gmock/gmock-matchers.h>
 #include <sstream>
-
 
 
 TEST(Log_Tests, ErrorMessagesLogged)
@@ -14,7 +14,7 @@ TEST(Log_Tests, ErrorMessagesLogged)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ("   [ERROR] Error message\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"(   [ERROR] Error message)"));
 }
 
 
@@ -28,7 +28,7 @@ TEST(Log_Tests, WarningMessagesLogged)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] Warning message\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] Warning message)"));
 }
 
 
@@ -42,7 +42,7 @@ TEST(Log_Tests, InfoMessagesLogged)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ("    [INFO] Info message\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"(    [INFO] Info message)"));
 }
 
 
@@ -56,7 +56,7 @@ TEST(Log_Tests, DebugMessagesLogged)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ("   [DEBUG]     Debug message\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"(   [DEBUG]     Debug message)"));
 }
 
 TEST(Log_Tests, ProgressMessagesLogged)
@@ -69,7 +69,7 @@ TEST(Log_Tests, ProgressMessagesLogged)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ("[PROGRESS] Progress message\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([PROGRESS] Progress message)"));
 }
 
 TEST(Log_Tests, NoticeMessagesLogged)
@@ -82,5 +82,5 @@ TEST(Log_Tests, NoticeMessagesLogged)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ("  [NOTICE] Notice message\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"(  [NOTICE] Notice message)"));
 }

--- a/tests/ModLoaderTests.cpp
+++ b/tests/ModLoaderTests.cpp
@@ -25,7 +25,7 @@ TEST(ModLoaderTests, LoadModsLogsWhenNoMods)
 	std::stringstream actualStream(actualOutput);
 
 	EXPECT_TRUE(mods.empty());
-	EXPECT_THAT(actualStream.str(), testing::HasSubstr(R"(    [INFO] No mods were detected in savegame. Skipping mod processing.)"));
+	EXPECT_THAT(actualStream.str(), testing::HasSubstr(R"([INFO] No mods were detected in savegame. Skipping mod processing.)"));
 }
 
 

--- a/tests/ModLoaderTests.cpp
+++ b/tests/ModLoaderTests.cpp
@@ -25,7 +25,7 @@ TEST(ModLoaderTests, LoadModsLogsWhenNoMods)
 	std::stringstream actualStream(actualOutput);
 
 	EXPECT_TRUE(mods.empty());
-	EXPECT_EQ(actualStream.str(), "    [INFO] No mods were detected in savegame. Skipping mod processing.\n");
+	EXPECT_THAT(actualStream.str(), testing::HasSubstr(R"(    [INFO] No mods were detected in savegame. Skipping mod processing.)"));
 }
 
 

--- a/tests/ParserHelperTests.cpp
+++ b/tests/ParserHelperTests.cpp
@@ -1,8 +1,8 @@
 #include "../CommonRegexes.h"
 #include "../ParserHelpers.h"
 #include "gtest/gtest.h"
+#include <gmock/gmock-matchers.h>
 #include <sstream>
-
 
 
 TEST(ParserHelper_Tests, IgnoreItemIgnoresSimpleText)
@@ -84,7 +84,7 @@ TEST(ParserHelper_Tests, ignoreAndLogItemLogsIgnoredKeyword)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ("   [DEBUG]     Ignoring keyword: key3\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"(   [DEBUG]     Ignoring keyword: key3)"));
 }
 
 
@@ -148,7 +148,7 @@ TEST(ParserHelper_Tests, stringToIntegerLogsNotFullyMatchingInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to integer - invalid argument: 345 foo\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to integer - invalid argument: 345 foo)"));
 	ASSERT_EQ(345, theInteger);
 }
 
@@ -164,7 +164,7 @@ TEST(ParserHelper_Tests, stringToIntegerLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to integer - invalid argument: foo\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to integer - invalid argument: foo)"));
 	ASSERT_EQ(0, theInteger);
 }
 TEST(ParserHelper_Tests, stringToDoubleLogsNotFullyMatchingInput)
@@ -179,7 +179,7 @@ TEST(ParserHelper_Tests, stringToDoubleLogsNotFullyMatchingInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to double - invalid argument: 345.69 foo\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to double - invalid argument: 345.69 foo)"));
 	ASSERT_EQ(345.69, theDouble);
 }
 
@@ -195,7 +195,7 @@ TEST(ParserHelper_Tests, stringToDoubleLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to double - invalid argument: foo\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to double - invalid argument: foo)"));
 	ASSERT_EQ(0, theDouble);
 }
 
@@ -420,7 +420,7 @@ TEST(ParserHelper_Tests, SingleIntLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to integer - invalid argument: foo\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to integer - invalid argument: foo)"));
 	ASSERT_EQ(0, theInteger.getInt());
 }
 
@@ -492,7 +492,7 @@ TEST(ParserHelper_Tests, SingleLlongLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to integer - invalid argument: foo\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to integer - invalid argument: foo)"));
 	ASSERT_EQ(0, theLlong.getLlong());
 }
 
@@ -508,7 +508,7 @@ TEST(ParserHelper_Tests, SingleULlongLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to integer - invalid argument: foo\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to integer - invalid argument: foo)"));
 	ASSERT_EQ(0, theULlong.getULlong());
 }
 
@@ -683,7 +683,7 @@ TEST(ParserHelper_Tests, SingleDoubleLogsNotFullyMatchingInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to double - invalid argument: 345.345 foo\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to double - invalid argument: 345.345 foo)"));
 	ASSERT_EQ(345.345, theDouble.getDouble());
 }
 
@@ -699,7 +699,7 @@ TEST(ParserHelper_Tests, SingleDoubleLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	ASSERT_EQ(" [WARNING] string to double - invalid argument: foo\n", log.str());
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to double - invalid argument: foo)"));
 	ASSERT_EQ(0, theDouble.getDouble());
 }
 

--- a/tests/ParserHelperTests.cpp
+++ b/tests/ParserHelperTests.cpp
@@ -84,7 +84,7 @@ TEST(ParserHelper_Tests, ignoreAndLogItemLogsIgnoredKeyword)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"(   [DEBUG]     Ignoring keyword: key3)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([DEBUG]     Ignoring keyword: key3)"));
 }
 
 
@@ -148,7 +148,7 @@ TEST(ParserHelper_Tests, stringToIntegerLogsNotFullyMatchingInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to integer - invalid argument: 345 foo)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([WARNING] string to integer - invalid argument: 345 foo)"));
 	ASSERT_EQ(345, theInteger);
 }
 
@@ -164,7 +164,7 @@ TEST(ParserHelper_Tests, stringToIntegerLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to integer - invalid argument: foo)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([WARNING] string to integer - invalid argument: foo)"));
 	ASSERT_EQ(0, theInteger);
 }
 TEST(ParserHelper_Tests, stringToDoubleLogsNotFullyMatchingInput)
@@ -179,7 +179,7 @@ TEST(ParserHelper_Tests, stringToDoubleLogsNotFullyMatchingInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to double - invalid argument: 345.69 foo)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([WARNING] string to double - invalid argument: 345.69 foo)"));
 	ASSERT_EQ(345.69, theDouble);
 }
 
@@ -195,7 +195,7 @@ TEST(ParserHelper_Tests, stringToDoubleLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to double - invalid argument: foo)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([WARNING] string to double - invalid argument: foo)"));
 	ASSERT_EQ(0, theDouble);
 }
 
@@ -420,7 +420,7 @@ TEST(ParserHelper_Tests, SingleIntLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to integer - invalid argument: foo)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([WARNING] string to integer - invalid argument: foo)"));
 	ASSERT_EQ(0, theInteger.getInt());
 }
 
@@ -492,7 +492,7 @@ TEST(ParserHelper_Tests, SingleLlongLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to integer - invalid argument: foo)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([WARNING] string to integer - invalid argument: foo)"));
 	ASSERT_EQ(0, theLlong.getLlong());
 }
 
@@ -508,7 +508,7 @@ TEST(ParserHelper_Tests, SingleULlongLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to integer - invalid argument: foo)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([WARNING] string to integer - invalid argument: foo)"));
 	ASSERT_EQ(0, theULlong.getULlong());
 }
 
@@ -683,7 +683,7 @@ TEST(ParserHelper_Tests, SingleDoubleLogsNotFullyMatchingInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to double - invalid argument: 345.345 foo)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([WARNING] string to double - invalid argument: 345.345 foo)"));
 	ASSERT_EQ(345.345, theDouble.getDouble());
 }
 
@@ -699,7 +699,7 @@ TEST(ParserHelper_Tests, SingleDoubleLogsInvalidInput)
 
 	std::cout.rdbuf(stdOutBuf);
 
-	EXPECT_THAT(log.str(), testing::HasSubstr(R"( [WARNING] string to double - invalid argument: foo)"));
+	EXPECT_THAT(log.str(), testing::HasSubstr(R"([WARNING] string to double - invalid argument: foo)"));
 	ASSERT_EQ(0, theDouble.getDouble());
 }
 

--- a/tests/ParserTests.cpp
+++ b/tests/ParserTests.cpp
@@ -405,7 +405,8 @@ TEST(Parser_Tests, IgnoreAndLogUnregisteredItemsIgnoresAndLogsUnregisteredItems)
 	std::cout.rdbuf(std_out_buf);
 	std::string actual_output = log.str();
 
-	EXPECT_EQ(actual_output, "   [DEBUG]     Ignoring keyword: key\n   [DEBUG]     Ignoring keyword: key_two\n");
+	EXPECT_THAT(actual_output, testing::HasSubstr(R"(   [DEBUG]     Ignoring keyword: key)"));
+	EXPECT_THAT(actual_output, testing::HasSubstr(R"(   [DEBUG]     Ignoring keyword: key_two)"));
 }
 
 

--- a/tests/ParserTests.cpp
+++ b/tests/ParserTests.cpp
@@ -405,8 +405,8 @@ TEST(Parser_Tests, IgnoreAndLogUnregisteredItemsIgnoresAndLogsUnregisteredItems)
 	std::cout.rdbuf(std_out_buf);
 	std::string actual_output = log.str();
 
-	EXPECT_THAT(actual_output, testing::HasSubstr(R"(   [DEBUG]     Ignoring keyword: key)"));
-	EXPECT_THAT(actual_output, testing::HasSubstr(R"(   [DEBUG]     Ignoring keyword: key_two)"));
+	EXPECT_THAT(actual_output, testing::HasSubstr(R"([DEBUG]     Ignoring keyword: key)"));
+	EXPECT_THAT(actual_output, testing::HasSubstr(R"([DEBUG]     Ignoring keyword: key_two)"));
 }
 
 


### PR DESCRIPTION
This is a NON-backwards compatible change that adds a timestamp to all console output, for the sake of Fronter requiring it in order to properly display accurate data in Fronter log.

This will break any test that relies on exact matches of console logs, and will need to be fixed with 
`EXPECT_THAT(... , testing:HasSubstr(...))`