### PR TITLE
Clamp invalid RGB components when constructing color

### DIFF
--- a/Color.cpp
+++ b/Color.cpp
@@ -13,7 +13,8 @@
 
 
 
-commonItems::Color::Color(std::array<int, 3> rgbComponents): rgbComponents(rgbComponents) {
+commonItems::Color::Color(std::array<int, 3> rgbComponents): rgbComponents(rgbComponents)
+{
 	for (auto& component: this->rgbComponents)
 	{
 		if (component < 0)

--- a/Color.cpp
+++ b/Color.cpp
@@ -1,5 +1,6 @@
 #include "Color.h"
 #include "CommonRegexes.h"
+#include "Log.h"
 #include "ParserHelpers.h"
 #include "StringUtils.h"
 #include <algorithm>
@@ -10,6 +11,25 @@
 #include <regex>
 #include <sstream>
 
+
+
+commonItems::Color::Color(std::array<int, 3> rgbComponents): rgbComponents(rgbComponents) {
+	for (auto& component: rgbComponents)
+	{
+		if (component < 0)
+		{
+			Log(LogLevel::Warning) << "RGB color component " << component << " is less than 0. Clamping to 0.";
+			component = 0;
+		}
+		else if (component > 255)
+		{
+			Log(LogLevel::Warning) << "RGB color component " << component << " is greater than 255. Clamping to 255.";
+			component = 255;
+		}
+	}
+
+	deriveHsvFromRgb();
+}
 
 
 std::string commonItems::Color::outputRgb() const

--- a/Color.cpp
+++ b/Color.cpp
@@ -14,7 +14,7 @@
 
 
 commonItems::Color::Color(std::array<int, 3> rgbComponents): rgbComponents(rgbComponents) {
-	for (auto& component: rgbComponents)
+	for (auto& component: this->rgbComponents)
 	{
 		if (component < 0)
 		{

--- a/Color.h
+++ b/Color.h
@@ -47,7 +47,7 @@ class Color
   public:
 	class Factory;
 	Color() = default;
-	explicit Color(std::array<int, 3> rgbComponents): rgbComponents(rgbComponents) { deriveHsvFromRgb(); }
+	explicit Color(std::array<int, 3> rgbComponents);
 	explicit Color(std::array<int, 3> rgbComponents, float alpha): rgbComponents(rgbComponents), alpha(alpha) { deriveHsvFromRgb(); }
 	explicit Color(std::array<float, 3> hsvComponents): hsvComponents(hsvComponents) { deriveRgbFromHsv(); }
 	explicit Color(std::array<float, 3> hsvComponents, float alpha): hsvComponents(hsvComponents), alpha(alpha) { deriveRgbFromHsv(); }

--- a/tests/ColorTests.cpp
+++ b/tests/ColorTests.cpp
@@ -990,5 +990,44 @@ TEST(Color_Tests, ColorPaletteCanBeCleared)
 	ASSERT_TRUE(colorFactory.getRegisteredColors().empty());
 }
 
+TEST(Color_Tests, InvalidRgbComponentsAreClamped)
+{
+	commonItems::Color testColor(std::array<int, 3>{-1, 10, 10});
+	auto [r1, g1, b1] = testColor.getRgbComponents();
+	ASSERT_EQ(0, r1);
+	ASSERT_EQ(10, g1);
+	ASSERT_EQ(10, b1);
+
+	testColor = commonItems::Color(std::array<int, 3>{300, 10, 10});
+	auto [r2, g2, b2] = testColor.getRgbComponents();
+	ASSERT_EQ(255, r2);
+	ASSERT_EQ(10, g2);
+	ASSERT_EQ(10, b2);
+
+	testColor = commonItems::Color(std::array<int, 3>{10, -1, 10});
+	auto [r3, g3, b3] = testColor.getRgbComponents();
+	ASSERT_EQ(10, r3);
+	ASSERT_EQ(0, g3);
+	ASSERT_EQ(10, b3);
+
+	testColor = commonItems::Color(std::array<int, 3>{10, 300, 10});
+	auto [r4, g4, b4] = testColor.getRgbComponents();
+	ASSERT_EQ(10, r4);
+	ASSERT_EQ(255, g4);
+	ASSERT_EQ(10, b4);
+
+	testColor = commonItems::Color(std::array<int, 3>{10, 10, -1});
+	auto [r5, g5, b5] = testColor.getRgbComponents();
+	ASSERT_EQ(10, r5);
+	ASSERT_EQ(10, g5);
+	ASSERT_EQ(0, b5);
+
+	testColor = commonItems::Color(std::array<int, 3>{10, 10, 300});
+	auto [r6, g6, b6] = testColor.getRgbComponents();
+	ASSERT_EQ(10, r6);
+	ASSERT_EQ(10, g6);
+	ASSERT_EQ(255, b6);
+}
+
 
 // RandomlyFluctuate() isn't easily testable, so skipped


### PR DESCRIPTION
Unfaithful copy of https://github.com/ParadoxGameConverters/PGCG.commonItems/pull/463