### PR TITLE
Handle yet another color format 🎨

### DIFF
--- a/Color.cpp
+++ b/Color.cpp
@@ -288,11 +288,18 @@ commonItems::Color commonItems::Color::Factory::getColor(std::istream& theStream
 		// This is a double list.
 		auto doubleStream = std::stringstream(questionableList);
 		auto rgb = getDoubles(doubleStream);
-		if (rgb.size() == 3) // This is not HSV, this is RGB doubles. Multiply by 255 and round to get normal rgb.
+		if (rgb.size() == 3)
+		{
+			// This is not HSV, this is RGB doubles. Just convert to ints to get normal RGB.
+			if (rgb[0] > 1 || rgb[1] > 1 || rgb[3] > 1)
+				return Color(std::array{static_cast<int>(std::round(rgb[0])), static_cast<int>(std::round(rgb[1])), static_cast<int>(std::round(rgb[2]))});
+
+			// If all RGB values are in the range 0-1, multiply by 255 and round to get normal RGB.
 			return Color(std::array{static_cast<int>(std::round(rgb[0] * 255.0)),
 				 static_cast<int>(std::round(rgb[1] * 255.0)),
 				 static_cast<int>(std::round(rgb[2] * 255.0))});
-		if (rgb.size() == 4) // this is a RGBA double situation. We shouldn't touch alpha.
+		}
+		if (rgb.size() == 4) // this is an RGBA double situation. We shouldn't touch alpha.
 			return Color(std::array{static_cast<int>(std::round(rgb[0] * 255.0)),
 								  static_cast<int>(std::round(rgb[1] * 255.0)),
 								  static_cast<int>(std::round(rgb[2] * 255.0))},

--- a/Color.cpp
+++ b/Color.cpp
@@ -291,7 +291,7 @@ commonItems::Color commonItems::Color::Factory::getColor(std::istream& theStream
 		if (rgb.size() == 3)
 		{
 			// This is not HSV, this is RGB doubles. Just convert to ints to get normal RGB.
-			if (rgb[0] > 1 || rgb[1] > 1 || rgb[3] > 1)
+			if (rgb[0] > 1 || rgb[1] > 1 || rgb[2] > 1)
 				return Color(std::array{static_cast<int>(std::round(rgb[0])), static_cast<int>(std::round(rgb[1])), static_cast<int>(std::round(rgb[2]))});
 
 			// If all RGB values are in the range 0-1, multiply by 255 and round to get normal RGB.

--- a/tests/ColorTests.cpp
+++ b/tests/ColorTests.cpp
@@ -345,6 +345,23 @@ TEST(Color_Tests, ColorCanBeInitializedFromStream)
 	ASSERT_NEAR(0.5f, v, 0.01);
 }
 
+TEST(Color_Tests, ColorIsCorrectlyConstructedFromRGBFloats)
+{
+	std::stringstream input;
+	input << "= { 49.0 35.0 58.0 }";
+	const auto testColor = commonItems::Color::Factory{}.getColor(input);
+
+	auto [r, g, b] = testColor.getRgbComponents();
+	ASSERT_EQ(49, r);
+	ASSERT_EQ(35, g);
+	ASSERT_EQ(58, b);
+
+	auto [h, s, v] = testColor.getHsvComponents();
+	ASSERT_NEAR(0.7681f, h, 0.01);
+	ASSERT_NEAR(0.39655f, s, 0.01);
+	ASSERT_NEAR(0.22745f, v, 0.01);
+}
+
 TEST(Color_Tests, ColorRGBDoublesCanBeInitializedFromStream) // Yes, this is a thing.
 {
 	std::stringstream input;


### PR DESCRIPTION
Found in TFE mod for CK3:
```
        arianism = {
            color = { 49.0 35.0 58.0 }
```
![obraz](https://github.com/user-attachments/assets/1d1e4c96-8595-4f88-9099-8b4e866825fd)
![obraz](https://github.com/user-attachments/assets/2e0d4887-0507-41a4-9ae5-8d8b5384db78)
