### PR TITLE
Improved support for the ExistsEquals operator

### DIFF
--- a/CommonRegexes.h
+++ b/CommonRegexes.h
@@ -11,9 +11,9 @@ namespace commonItems
 {
 
 // catchall:
-//		We grab everything that's NOT =, { or }, OR we grab everything within quotes, except newlines, which we already
+//		We grab everything that's NOT ?, =, { or }, OR we grab everything within quotes, except newlines, which we already
 //		drop in the parser.
-inline constexpr const char* catchallRegex = R"([^=^{^}]+|".+")";
+inline constexpr const char* catchallRegex = R"([^\?^=^{^}]+|".+")";
 
 // numbers
 inline constexpr const char* integerRegex = R"(-?\d+)";

--- a/Parser.cpp
+++ b/Parser.cpp
@@ -351,6 +351,19 @@ std::string commonItems::getNextLexeme(std::istream& theStream)
 			}
 			break;
 		}
+		else if (!inQuotes && !inLiteralQuote && inputChar == '?')
+		{
+			// We've likely encountered the beginning of an ExistEquals operator.
+			if (toReturn.empty())
+			{
+				toReturn += inputChar;
+			}
+			else
+			{
+				theStream.putback('?');
+				break;
+			}
+		}
 		else if (!inQuotes && !inLiteralQuote && inputChar == '=')
 		{
 			if (toReturn.empty() || toReturn == "?")

--- a/tests/CommonRegexesTests.cpp
+++ b/tests/CommonRegexesTests.cpp
@@ -57,6 +57,14 @@ TEST(CommonRegexes_Tests, CatchallRegexMatchesQuotedInternalQuotes)
 }
 
 
+TEST(CommonRegexes_Tests, CatchallRegexDoesntMatchQuestionSign)
+{
+	std::smatch match;
+	const std::string test_string("1234-abcd?");
+	EXPECT_FALSE(std::regex_match(test_string, match, std::regex(commonItems::catchallRegex)));
+}
+
+
 TEST(CommonRegexes_Tests, CatchallRegexDoesntMatchEquals)
 {
 	std::smatch match;

--- a/tests/ParserTests.cpp
+++ b/tests/ParserTests.cpp
@@ -298,7 +298,7 @@ TEST(Parser_Tests, RegexesAreMatchedOnExistsEquals)
 	EXPECT_EQ("key", test.key);
 	EXPECT_EQ("value", test.value);
 
-   test = Test(input2);
+	test = Test(input2);
 	EXPECT_EQ("key", test.key);
 	EXPECT_EQ("value", test.value);
 
@@ -553,7 +553,7 @@ TEST(Parser_Tests, IgnoreAndStoreUnregisteredItemsIgnoresUnregisteredItemsOnExis
 	input << "key ?= value1\n";
 	input << "key_two ?= { nested_item}\n";
 	input << "key_three?= value3\n"; // no space before the ExistsEquals
-	input << "key_four ?=value4\n";  // no space after the ExistsEquals
+	input << "key_four ?=value4\n";	// no space after the ExistsEquals
 
 	std::set<std::string> ignored_items;
 	commonItems::parser parser;

--- a/tests/ParserTests.cpp
+++ b/tests/ParserTests.cpp
@@ -73,6 +73,29 @@ TEST(Parser_Tests, KeywordsAreMatchedForExistsEquals)
 	EXPECT_EQ("value", test.value);
 }
 
+TEST(Parser_Tests, KeywordsAreMatchedForExistsEqualsWithoutPrecedingWhitespace)
+{
+	std::stringstream input{"key?= value"}; // no whitespace between key and ?=
+	class Test: commonItems::parser
+	{
+	  public:
+		explicit Test(std::istream& stream)
+		{
+			registerKeyword("key", [this](const std::string& keyword, std::istream& theStream) {
+				key = keyword;
+				value = commonItems::getString(theStream);
+			});
+			parseStream(stream);
+		}
+		std::string key;
+		std::string value;
+	};
+	const auto test = Test(input);
+
+	EXPECT_EQ("key", test.key);
+	EXPECT_EQ("value", test.value);
+}
+
 TEST(Parser_Tests, FunctionObjectEquivalentToParse)
 {
 	std::stringstream input{"key = value"};
@@ -253,7 +276,9 @@ TEST(Parser_Tests, RegexesAreMatched)
 
 TEST(Parser_Tests, RegexesAreMatchedOnExistsEquals)
 {
-	std::stringstream input{"key ?= value"};
+	std::stringstream input1{"key ?= value"};
+	std::stringstream input2{"key?= value"}; // no whitespace between key and ?=
+	std::stringstream input3{"key ?=value"}; // no whitespace between ?= and value
 	class Test: commonItems::parser
 	{
 	  public:
@@ -268,8 +293,16 @@ TEST(Parser_Tests, RegexesAreMatchedOnExistsEquals)
 		std::string key;
 		std::string value;
 	};
-	const auto test = Test(input);
 
+	auto test = Test(input1);
+	EXPECT_EQ("key", test.key);
+	EXPECT_EQ("value", test.value);
+
+   test = Test(input2);
+	EXPECT_EQ("key", test.key);
+	EXPECT_EQ("value", test.value);
+
+	test = Test(input3);
 	EXPECT_EQ("key", test.key);
 	EXPECT_EQ("value", test.value);
 }
@@ -471,8 +504,10 @@ TEST(Parser_Tests, IgnoreAndLogUnregisteredItemsIgnoresAndLogsUnregisteredItemsO
 {
 	std::stringstream input;
 	input << std::noskipws;
-	input << "key ?= value\n";
+	input << "key ?= value1\n";
 	input << "key_two ?= { nested_item}\n";
+	input << "key_three?= value3\n"; // no space before the ExistsEquals
+	input << "key_four ?=value4\n";	// no space after the ExistsEquals
 
 	commonItems::parser parser;
 	parser.IgnoreAndLogUnregisteredItems();
@@ -489,6 +524,8 @@ TEST(Parser_Tests, IgnoreAndLogUnregisteredItemsIgnoresAndLogsUnregisteredItemsO
 
 	EXPECT_THAT(actual_output, testing::HasSubstr(R"([DEBUG]     Ignoring keyword: key)"));
 	EXPECT_THAT(actual_output, testing::HasSubstr(R"([DEBUG]     Ignoring keyword: key_two)"));
+	EXPECT_THAT(actual_output, testing::HasSubstr(R"([DEBUG]     Ignoring keyword: key_three)"));
+	EXPECT_THAT(actual_output, testing::HasSubstr(R"([DEBUG]     Ignoring keyword: key_four)"));
 }
 
 
@@ -513,8 +550,10 @@ TEST(Parser_Tests, IgnoreAndStoreUnregisteredItemsIgnoresUnregisteredItemsOnExis
 {
 	std::stringstream input;
 	input << std::noskipws;
-	input << "key ?= value\n";
+	input << "key ?= value1\n";
 	input << "key_two ?= { nested_item}\n";
+	input << "key_three?= value3\n"; // no space before the ExistsEquals
+	input << "key_four ?=value4\n";  // no space after the ExistsEquals
 
 	std::set<std::string> ignored_items;
 	commonItems::parser parser;
@@ -523,5 +562,5 @@ TEST(Parser_Tests, IgnoreAndStoreUnregisteredItemsIgnoresUnregisteredItemsOnExis
 
 	parser.parseStream(input);
 
-	EXPECT_THAT(ignored_items, testing::UnorderedElementsAre("key", "key_two"));
+	EXPECT_THAT(ignored_items, testing::UnorderedElementsAre("key", "key_two", "key_three", "key_four"));
 }


### PR DESCRIPTION
Tested in the CK3 console, the ExistsEquals operator doesn't need to be surrounded by whitespace.
<img width="385" height="125" alt="ck3_console_test" src="https://github.com/user-attachments/assets/c3ae252a-efa8-4e51-9898-c69aaeff42d5" />
<img width="447" height="163" alt="obraz" src="https://github.com/user-attachments/assets/5b04461f-572e-4c6d-be1a-e20eb4d7fbe3" />

